### PR TITLE
Greg/swagger fix float

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -1940,13 +1940,13 @@
                     "type": "object",
                     "format": "int64",
                     "description": "List of trailer ID's associated with the driver for the day.",
-                    "example": [010293, 192933]
+                    "example": [10293, 192933]
                   },
                   "vehicleIds": {
                     "type": "object",
                     "format": "int64",
                     "description": "List of vehicle ID's associated with the driver for the day.",
-                    "example": [192319, 012958]
+                    "example": [192319, 12958]
                   }
                 }
               }

--- a/swagger.json
+++ b/swagger.json
@@ -2560,18 +2560,18 @@
                                             "example": 1453449599999
                                         },
                                         "X": {
-                                            "type": "float",
-                                            "format": "float64",
+                                            "type": "number",
+                                            "format": "float",
                                             "example": 0.01
                                         },
                                         "Y": {
-                                            "type": "float",
-                                            "format": "float64",
+                                            "type": "number",
+                                            "format": "float",
                                             "example": 1.23
                                         },
                                         "Z": {
-                                            "type": "float",
-                                            "format": "float64",
+                                            "type": "number",
+                                            "format": "float",
                                             "example": 2.55
                                         }
                                     }


### PR DESCRIPTION
Fixing several validation issues with our swagger.json file in api-docs:
 1. Invalid JSON numbers (leading 0)
 2. Invalid type and format attributes for MachineHistoryResponse

The latter issue was causing about a dozen or so validation errors on editor.swagger.io