### PR TITLE
swagger: Add support for dispatch routes

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -2356,6 +2356,132 @@
                 }
             }
         },
+        "DispatchJobCreate": {
+            "type": "object",
+            "required": [
+                "scheduled_arrival_time_ms",
+                "destination_lat",
+                "destination_lng"
+            ],
+            "properties": {
+                "driver_id": {
+                    "type": "integer",
+                    "format": "int64",
+                    "description":  "ID of the driver assigned to the dispatch job.",
+                    "example": 444
+                },
+                "vehicle_id": {
+                    "type": "integer",
+                    "format": "int64",
+                    "description": "ID of the vehicle used for the dispatch job.",
+                    "example": 112
+                },
+                "scheduled_arrival_time_ms": {
+                    "type": "integer",
+                    "format": "int64",
+                    "description": "The time at which the assigned driver is scheduled to arrive at the job destination.",
+                    "example": 1462881998034
+                },
+                "notes": {
+                    "type": "string",
+                    "description": "Notes regarding the details of this job.",
+                    "example": "Ensure crates are stacked no more than 3 high."
+                },
+                "destination_name": {
+                    "type": "string",
+                    "description": "The name of the job destination.",
+                    "example": "ACME Inc. Philadelphia HQ"
+                },
+                "destination_address": {
+                    "type": "string",
+                    "description": "The address of the job destination, as it would be recognized if provided to maps.google.com",
+                    "example": "123 Main St, Philadelphia, PA 19106"
+                },
+                "destination_lat": {
+                    "type": "number",
+                    "format": "float",
+                    "description": "Latitude of the destination in decimal degrees.",
+                    "example": 123.456
+                },
+                "destination_lng": {
+                    "type": "number",
+                    "format": "float",
+                    "description": "Latitude of the destination in decimal degrees.",
+                    "example": 37.459
+                }
+            }
+        },
+        "DispatchJob": {
+            "allOf": [
+                {
+                    "type": "object",
+                    "required": [
+                        "id",
+                        "group_id",
+                        "dispatch_route_id",
+                        "job_state"
+                    ],
+                    "properties": {
+                        "id": {
+                            "type": "integer",
+                            "format": "int64",
+                            "description": "ID of the Samsara dispatch job.",
+                            "example": 773
+                        },
+                        "group_id": {
+                            "type": "integer",
+                            "format": "int64"
+                        },
+                        "dispatch_route_id": {
+                            "type": "integer",
+                            "format": "int64",
+                            "description": "ID of the route that this job belongs to.",
+                            "example": 55
+                        },
+                        "job_state": {
+                            "type": "string",
+                            "enum": [
+                                "JobState_Unassigned",
+                                "JobState_Scheduled",
+                                "JobState_EnRoute",
+                                "JobState_Arrived",
+                                "JobState_Completed",
+                                "JobState_Skipped"
+                            ],
+                            "description": "The current state of the dispatch job.",
+                            "example": "JobState_Unassigned"
+                        },
+                        "en_route_at_ms": {
+                            "type": "integer",
+                            "format": "int64",
+                            "description": "The time at which the assigned driver started fulfilling the job (e.g. started driving to the destination).",
+                            "example": 1462881998034
+                        },
+                        "arrived_at_ms": {
+                            "type": "integer",
+                            "format": "int64",
+                            "description": "The time at which the driver arrived at the job destination.",
+                            "example": 1462881998034
+                        },
+                        "completed_at_ms": {
+                            "type": "integer",
+                            "format": "int64",
+                            "description": "The time at which the job was marked complete (e.g. started driving to the next destination).",
+                            "example": 1462881998034
+                        },
+                        "skipped_at_ms": {
+                            "type": "integer",
+                            "format": "int64",
+                            "description": "The time at which the job was marked skipped.",
+                            "example": 1462881998034
+                        }
+                    }
+                },
+                {
+                    "$ref": "#/definitions/DispatchJobCreate"
+                }
+            ]
+        },
         "Machine": {
             "type": "object",
             "description": "Contains information about a machine.",

--- a/swagger.json
+++ b/swagger.json
@@ -1077,6 +1077,42 @@
                 }
             }
         },
+        "/fleet/dispatch/routes/{route_id}": {
+            "get": {
+                "tags": [
+                    "Default",
+                    "Fleet",
+                    "Routes"
+                ],
+                "summary": "/fleet/dispatch/routes/{route_id:[0-9]+}",
+                "description": "Fetch a dispatch route by id.",
+                "operationId": "getDispatchRouteById",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    { "$ref": "#/parameters/accessTokenParam" },
+                    { "$ref": "#/parameters/routeIdParam" }
+               ],
+                "responses": {
+                    "200": {
+                        "description": "The dispatch route corresponding to route_id.",
+                        "schema": {
+                            "$ref": "#/definitions/DispatchRoute"
+                        }
+                    },
+                    "default": {
+                        "description": "Unexpected error.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/fleet/dispatch_jobs": {
             "post": {
                 "tags": [
@@ -2822,6 +2858,13 @@
                     }
                 }
             }
+        },
+        "routeIdParam": {
+            "name": "route_id",
+            "in": "path",
+            "required": true,
+            "description": "The route ID.",
+            "type": "integer"
         },
         "routeEndTimeParam": {
             "name": "end_time",

--- a/swagger.json
+++ b/swagger.json
@@ -997,6 +997,45 @@
                 }
             }
         },
+        "/fleet/dispatch/routes": {
+            "get": {
+                "tags": [
+                    "Default", "Fleet", "Routes"
+                ],
+                "summary": "/fleet/dispatch/routes",
+                "description": "Fetch all of the dispatch routes for the group.",
+                "operationId": "fetchAllDispatchRoutes",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    { "$ref": "#/parameters/accessTokenParam" },
+                    { "$ref": "#/parameters/routeGroupIdParam" },
+                    { "$ref": "#/parameters/routeEndTimeParam" },
+                    { "$ref": "#/parameters/routeDurationParam" }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "All dispatch route objects for the group.",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/DispatchRoute"
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Unexpected error.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/fleet/dispatch_jobs": {
             "post": {
                 "tags": [
@@ -2742,6 +2781,27 @@
                     }
                 }
             }
+        },
+        "routeEndTimeParam": {
+            "name": "end_time",
+            "description": "Time in unix milliseconds that represents the oldest routes to return. Used in combination with duration. Defaults to now.",
+            "required": false,
+            "in": "query",
+            "type": "integer"
+        },
+        "routeDurationParam": {
+            "name": "duration",
+            "description": "Time in milliseconds that represents the duration before end_time to query. Defaults to one day.",
+            "required": false,
+            "in": "query",
+            "type": "integer"
+        },
+        "routeGroupIdParam": {
+            "name": "group_id",
+            "description": "Optional group ID if the organization has multiple groups (uncommon).",
+            "required": false,
+            "in": "query",
+            "type": "integer"
         }
     }
 }

--- a/swagger.json
+++ b/swagger.json
@@ -1021,10 +1021,7 @@
                     "200": {
                         "description": "All dispatch route objects for the group.",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/DispatchRoute"
-                            }
+                            "$ref": "#/definitions/DispatchRoutes"
                         }
                     },
                     "default": {
@@ -1175,6 +1172,44 @@
                 "responses": {
                     "200": {
                         "description": "Successfully deleted the dispatch route. No response body is returned."
+                    },
+                    "default": {
+                        "description": "Unexpected error.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/fleet/drivers/{driver_id}/dispatch/routes": {
+            "get": {
+                "tags": [
+                    "Default",
+                    "Fleet",
+                    "Routes"
+                ],
+                "summary": "/fleet/drivers/{driver_id:[0-9]+}/dispatch/routes",
+                "description": "Fetch all of the dispatch routes for a given driver.",
+                "operationId": "getDispatchRoutesByDriverId",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    { "$ref": "#/parameters/accessTokenParam" },
+                    { "$ref": "#/parameters/driverIdParam" },
+                    { "$ref": "#/parameters/routeEndTimeParam" },
+                    { "$ref": "#/parameters/routeDurationParam" }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Returns the dispatch routes for the given driver_id.",
+                        "schema": {
+                            "$ref": "#/definitions/DispatchRoutes"
+                        }
                     },
                     "default": {
                         "description": "Unexpected error.",
@@ -2792,6 +2827,12 @@
                 }
             ]
         },
+        "DispatchRoutes": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/DispatchRoute"
+            }
+        },
         "Machine": {
             "type": "object",
             "description": "Contains information about a machine.",
@@ -2930,6 +2971,13 @@
                     }
                 }
             }
+        },
+        "driverIdParam": {
+            "name": "driver_id",
+            "in": "path",
+            "required": true,
+            "description": "The driver ID.",
+            "type": "integer"
         },
         "routeIdParam": {
             "name": "route_id",

--- a/swagger.json
+++ b/swagger.json
@@ -1034,6 +1034,47 @@
                         }
                     }
                 }
+            },
+            "post": {
+                "tags": [
+                    "Default", "Fleet", "Routes"
+                ],
+                "summary": "/fleet/dispatch/routes",
+                "description": "Create a new dispatch route.",
+                "operationId": "createDispatchRoute",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/accessTokenParam"
+                    },
+                    {
+                        "name": "createDispatchRouteParams",
+                        "required": true,
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/DispatchRouteCreate"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Created route object including the new route ID.",
+                        "schema": {
+                            "$ref": "#/definitions/DispatchRoute"
+                        }
+                    },
+                    "default": {
+                        "description": "Unexpected error.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
             }
         },
         "/fleet/dispatch_jobs": {

--- a/swagger.json
+++ b/swagger.json
@@ -1254,6 +1254,44 @@
                 }
             }
         },
+        "/fleet/vehicles/{vehicle_id}/dispatch/routes": {
+            "get": {
+                "tags": [
+                    "Default",
+                    "Fleet",
+                    "Routes"
+                ],
+                "summary": "/fleet/vehicles/{vehicle_id:[0-9]+}/dispatch/routes",
+                "description": "Fetch all of the dispatch routes for a given vehicle.",
+                "operationId": "getDispatchRoutesByVehicleId",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    { "$ref": "#/parameters/accessTokenParam" },
+                    { "$ref": "#/parameters/vehicleIdParam" },
+                    { "$ref": "#/parameters/routeEndTimeParam" },
+                    { "$ref": "#/parameters/routeDurationParam" }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Returns all of the dispatch routes for the given vehicle_id.",
+                        "schema": {
+                            "$ref": "#/definitions/DispatchRoutes"
+                        }
+                    },
+                    "default": {
+                        "description": "Unexpected error.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/fleet/dispatch_jobs": {
             "post": {
                 "tags": [
@@ -3012,6 +3050,14 @@
             "required": true,
             "description": "The driver ID.",
             "type": "integer"
+        },
+        "vehicleIdParam": {
+            "name": "vehicle_id",
+            "in": "path",
+            "required": true,
+            "description": "The vehicle ID.",
+            "type": "integer",
+            "format": "int64"
         },
         "routeIdParam": {
             "name": "route_id",

--- a/swagger.json
+++ b/swagger.json
@@ -1150,6 +1150,39 @@
                         }
                     }
                 }
+            },
+            "delete": {
+                "tags": [
+                    "Default", "Fleet", "Routes"
+                ],
+                "summary": "/fleet/dispatch/routes/{route_id:[0-9]+}/",
+                "description": "Delete a dispatch route and its associated jobs.",
+                "operationId": "deleteDispatchRouteById",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/accessTokenParam"
+                    },
+                    {
+                        "$ref": "#/parameters/routeIdParam"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully deleted the dispatch route. No response body is returned."
+                    },
+                    "default": {
+                        "description": "Unexpected error.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
             }
         },
         "/fleet/dispatch_jobs": {

--- a/swagger.json
+++ b/swagger.json
@@ -2482,6 +2482,128 @@
                 }
             ]
         },
+        "DispatchRouteBase": {
+            "type": "object",
+            "required": [
+                "name",
+                "scheduled_start_ms",
+                "scheduled_end_ms",
+                "start_location_lat",
+                "start_location_lng"
+            ],
+            "properties": {
+                "vehicle_id": {
+                    "type": "integer",
+                    "format": "int64",
+                    "description":  "ID of the vehicle assigned to the dispatch route. One of driver_id OR vehicle_id is required.",
+                    "example": 444
+                },
+                "driver_id": {
+                    "type": "integer",
+                    "format": "int64",
+                    "description":  "ID of the driver assigned to the dispatch route. One of driver_id OR vehicle_id is required.",
+                    "example": 555
+                },
+                "scheduled_start_ms": {
+                    "type": "integer",
+                    "format": "int64",
+                    "description": "The time in Unix epoch milliseconds that the route is scheduled to start.",
+                    "example": 1462881998034
+                },
+                "scheduled_end_ms": {
+                    "type": "integer",
+                    "format": "int64",
+                    "description": "The time in Unix epoch milliseconds that the last job in the route is scheduled to end.",
+                    "example": 1462881998034
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Descriptive name of this route.",
+                    "example": "Bid #123"
+                },
+                "group_id": {
+                    "type": "integer",
+                    "format": "int64",
+                    "description": "ID of the group if the organization has multiple groups (optional)."
+                },
+                "start_location_name": {
+                    "type": "string",
+                    "description": "The name of the route's starting location.",
+                    "example": "ACME Inc. Philadelphia HQ"
+                },
+                "start_location_address": {
+                    "type": "string",
+                    "description": "The address of the route's starting location, as it would be recognized if provided to maps.google.com",
+                    "example": "123 Main St, Philadelphia, PA 19106"
+                },
+                "start_location_lat": {
+                    "type": "number",
+                    "format": "float",
+                    "description": "Latitude of the destination in decimal degrees.",
+                    "example": 123.456
+                },
+                "start_location_lng": {
+                    "type": "number",
+                    "format": "float",
+                    "description": "Latitude of the destination in decimal degrees.",
+                    "example": 37.459
+                }
+            }
+        },
+        "DispatchRouteCreate": {
+            "allOf": [
+                {
+                    "type": "object",
+                    "required": [
+                        "dispatch_jobs"
+                    ],
+                    "properties": {
+                        "dispatch_jobs": {
+                            "description": "The dispatch jobs to create for this route.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/DispatchJobCreate"
+                            }
+                        }
+                    }
+                },
+                {
+                    "$ref": "#/definitions/DispatchRouteBase"
+                }
+            ]
+        },
+        "DispatchRoute": {
+            "required": [
+                "group_id"
+            ],
+            "allOf": [
+                {
+                    "type": "object",
+                    "required": [
+                        "id",
+                        "dispatch_jobs"
+                    ],
+                    "properties": {
+                        "id": {
+                            "type": "integer",
+                            "format": "int64",
+                            "description": "ID of the Samsara dispatch route.",
+                            "example": 556
+                        },
+                        "dispatch_jobs": {
+                            "description": "The dispatch jobs associated with this route.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/DispatchJob"
+                            }
+                        }
+                    }
+                },
+                {
+                    "$ref": "#/definitions/DispatchRouteBase"
+                }
+            ]
+        },
         "Machine": {
             "type": "object",
             "description": "Contains information about a machine.",

--- a/swagger.json
+++ b/swagger.json
@@ -3088,7 +3088,8 @@
             "in": "path",
             "required": true,
             "description": "The driver ID.",
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
         },
         "vehicleIdParam": {
             "name": "vehicle_id",
@@ -3103,7 +3104,8 @@
             "in": "path",
             "required": true,
             "description": "The route ID.",
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
         },
         "routeCreateParam": {
             "name": "createDispatchRouteParams",
@@ -3126,21 +3128,24 @@
             "description": "Time in unix milliseconds that represents the oldest routes to return. Used in combination with duration. Defaults to now.",
             "required": false,
             "in": "query",
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
         },
         "routeDurationParam": {
             "name": "duration",
             "description": "Time in milliseconds that represents the duration before end_time to query. Defaults to one day.",
             "required": false,
             "in": "query",
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
         },
         "routeGroupIdParam": {
             "name": "group_id",
             "description": "Optional group ID if the organization has multiple groups (uncommon).",
             "required": false,
             "in": "query",
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
         }
     }
 }

--- a/swagger.json
+++ b/swagger.json
@@ -1050,12 +1050,7 @@
                         "$ref": "#/parameters/accessTokenParam"
                     },
                     {
-                        "name": "createDispatchRouteParams",
-                        "required": true,
-                        "in": "body",
-                        "schema": {
-                            "$ref": "#/definitions/DispatchRouteCreate"
-                        }
+                        "$ref": "#/parameters/routeCreateParam"
                     }
                 ],
                 "responses": {
@@ -1209,6 +1204,45 @@
                         "description": "Returns the dispatch routes for the given driver_id.",
                         "schema": {
                             "$ref": "#/definitions/DispatchRoutes"
+                        }
+                    },
+                    "default": {
+                        "description": "Unexpected error.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "Default", "Fleet", "Routes"
+                ],
+                "summary": "/fleet/drivers/{driver_id:[0-9]+}/dispatch/routes",
+                "description": "Create a new dispatch route for the driver with driver_id.",
+                "operationId": "createDriverDispatchRoute",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/accessTokenParam"
+                    },
+                    {
+                        "$ref": "#/parameters/driverIdParam"
+                    },
+                    {
+                        "$ref": "#/parameters/routeCreateParam"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Created route object including the new route ID.",
+                        "schema": {
+                            "$ref": "#/definitions/DispatchRoute"
                         }
                     },
                     "default": {
@@ -2985,6 +3019,14 @@
             "required": true,
             "description": "The route ID.",
             "type": "integer"
+        },
+        "routeCreateParam": {
+            "name": "createDispatchRouteParams",
+            "required": true,
+            "in": "body",
+            "schema": {
+                "$ref": "#/definitions/DispatchRouteCreate"
+            }
         },
         "routeUpdateParam": {
             "name": "updateDispatchRouteParams",

--- a/swagger.json
+++ b/swagger.json
@@ -1111,6 +1111,45 @@
                         }
                     }
                 }
+            },
+            "put": {
+                "tags": [
+                    "Default", "Fleet", "Routes"
+                ],
+                "summary": "/fleet/dispatch/routes/{route_id:[0-9]+}/",
+                "description": "Update a dispatch route and its associated jobs.",
+                "operationId": "updateDispatchRouteById",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/accessTokenParam"
+                    },
+                    {
+                        "$ref": "#/parameters/routeIdParam"
+                    },
+                    {
+                        "$ref": "#/parameters/routeUpdateParam"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Update the dispatch route. Allowable updates include setting job state, adding or removing jobs, and changing job locations and times.",
+                        "schema": {
+                            "$ref": "#/definitions/DispatchRoute"
+                        }
+                    },
+                    "default": {
+                        "description": "Unexpected error.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
             }
         },
         "/fleet/dispatch_jobs": {
@@ -2865,6 +2904,14 @@
             "required": true,
             "description": "The route ID.",
             "type": "integer"
+        },
+        "routeUpdateParam": {
+            "name": "updateDispatchRouteParams",
+            "required": true,
+            "in": "body",
+            "schema": {
+                "$ref": "#/definitions/DispatchRoute"
+            }
         },
         "routeEndTimeParam": {
             "name": "end_time",

--- a/swagger.json
+++ b/swagger.json
@@ -1290,6 +1290,45 @@
                         }
                     }
                 }
+            },
+            "post": {
+                "tags": [
+                    "Default", "Fleet", "Routes"
+                ],
+                "summary": "/fleet/vehicles/{vehicle_id:[0-9]+}/dispatch/routes",
+                "description": "Create a new dispatch route for the vehicle with vehicle_id.",
+                "operationId": "createVehicleDispatchRoute",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/accessTokenParam"
+                    },
+                    {
+                        "$ref": "#/parameters/vehicleIdParam"
+                    },
+                    {
+                        "$ref": "#/parameters/routeCreateParam"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Created route object including the new route ID.",
+                        "schema": {
+                            "$ref": "#/definitions/DispatchRoute"
+                        }
+                    },
+                    "default": {
+                        "description": "Unexpected error.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
             }
         },
         "/fleet/dispatch_jobs": {


### PR DESCRIPTION
This PR adds support for all of the dispatch route REST endpoints in our swagger.json file. 

The routes added came from samsaradev.io/controllers/api/routes.go, with the exception of 
  * /fleet/drivers/{driver_id}/dispatch/routes/{route_id}
  * /fleet/vehicles/{vehicle_id}/dispatch/routes/{route_id}

For now, those will be unexported functions that only we know about, since exposing them may add unnecessary complexity.
