### PR TITLE
Greg/swagger: Update swagger with dispatch route history fetch endpoint

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -1173,6 +1173,51 @@
                 }
             }
         },
+        "/fleet/dispatch/routes/{route_id}/history": {
+            "get": {
+                "tags": [
+                    "Default",
+                    "Fleet",
+                    "Routes"
+                ],
+                "summary": "/fleet/dispatch/routes/{route_id:[0-9]+}/history",
+                "description": "Fetch the history of a dispatch route.",
+                "operationId": "getDispatchRouteHistory",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    { "$ref": "#/parameters/accessTokenParam" },
+                    { "$ref": "#/parameters/routeHistoryStartTimeParam" },
+                    { "$ref": "#/parameters/routeHistoryEndTimeParam" },
+                    {
+                        "name": "route_id",
+                        "in": "path",
+                        "required": true,
+                        "description": "ID of the route with history.",
+                        "type": "integer",
+                        "format": "int64"
+                    }
+               ],
+                "responses": {
+                    "200": {
+                        "description": "The historical route state changes between start_time and end_time.",
+                        "schema": {
+                            "$ref": "#/definitions/DispatchRouteHistory"
+                        }
+                    },
+                    "default": {
+                        "description": "Unexpected error.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/fleet/drivers/{driver_id}/dispatch/routes": {
             "parameters": [
                 {
@@ -2634,6 +2679,32 @@
                 "$ref": "#/definitions/DispatchRoute"
             }
         },
+        "DispatchRouteHistoricalEntry": {
+            "type": "object",
+            "properties": {
+                "changed_at_ms": {
+                    "type": "integer",
+                    "format": "int64",
+                    "description": "Timestamp that the route was updated, represented as Unix milliseconds since epoch.",
+                    "example": 1499411220000
+                },
+                "route": {
+                    "$ref": "#/definitions/DispatchRoute"
+                }
+            }
+        },
+        "DispatchRouteHistory": {
+            "type": "object",
+            "properties": {
+                "history": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/DispatchRouteHistoricalEntry"
+                    },
+                    "description":  "History of the route's state changes."
+                }
+            }
+        },
         "Machine": {
             "type": "object",
             "description": "Contains information about a machine.",
@@ -2800,6 +2871,22 @@
         "routeDurationParam": {
             "name": "duration",
             "description": "Time in milliseconds that represents the duration before end_time to query. Defaults to one day.",
+            "required": false,
+            "in": "query",
+            "type": "integer",
+            "format": "int64"
+        },
+        "routeHistoryStartTimeParam": {
+            "name": "start_time",
+            "description": "Timestamp representing the start of the period to fetch, inclusive. Used in combination with end_time. Defaults to 0.",
+            "required": false,
+            "in": "query",
+            "type": "integer",
+            "format": "int64"
+        },
+        "routeHistoryEndTimeParam": {
+            "name": "end_time",
+            "description": "Timestamp representing the end of the period to fetch, inclusive. Used in combination with start_time. Defaults to nowMs.",
             "required": false,
             "in": "query",
             "type": "integer",

--- a/swagger.json
+++ b/swagger.json
@@ -552,8 +552,9 @@
                     "name": "driver_id",
                     "in": "path",
                     "required": true,
-                    "description": "The driver ID.",
-                    "type": "integer"
+                    "description": "ID of the driver with HOS logs.",
+                    "type": "integer",
+                    "format": "int64"
                 },
                 {
                     "name": "hosLogsParam",
@@ -1070,6 +1071,19 @@
             }
         },
         "/fleet/dispatch/routes/{route_id}": {
+            "parameters": [
+                {
+                    "$ref": "#/parameters/accessTokenParam"
+                },
+                {
+                    "name": "route_id",
+                    "in": "path",
+                    "required": true,
+                    "description": "ID of the dispatch route.",
+                    "type": "integer",
+                    "format": "int64"
+                }
+            ],
             "get": {
                 "tags": [
                     "Default",
@@ -1085,10 +1099,6 @@
                 "produces": [
                     "application/json"
                 ],
-                "parameters": [
-                    { "$ref": "#/parameters/accessTokenParam" },
-                    { "$ref": "#/parameters/routeIdParam" }
-               ],
                 "responses": {
                     "200": {
                         "description": "The dispatch route corresponding to route_id.",
@@ -1118,12 +1128,6 @@
                     "application/json"
                 ],
                 "parameters": [
-                    {
-                        "$ref": "#/parameters/accessTokenParam"
-                    },
-                    {
-                        "$ref": "#/parameters/routeIdParam"
-                    },
                     {
                         "$ref": "#/parameters/routeUpdateParam"
                     }
@@ -1156,14 +1160,6 @@
                 "produces": [
                     "application/json"
                 ],
-                "parameters": [
-                    {
-                        "$ref": "#/parameters/accessTokenParam"
-                    },
-                    {
-                        "$ref": "#/parameters/routeIdParam"
-                    }
-                ],
                 "responses": {
                     "200": {
                         "description": "Successfully deleted the dispatch route. No response body is returned."
@@ -1178,6 +1174,19 @@
             }
         },
         "/fleet/drivers/{driver_id}/dispatch/routes": {
+            "parameters": [
+                {
+                    "$ref": "#/parameters/accessTokenParam"
+                },
+                {
+                    "name": "driver_id",
+                    "in": "path",
+                    "required": true,
+                    "description": "ID of the driver with the associated routes.",
+                    "type": "integer",
+                    "format": "int64"
+                }
+            ],
             "get": {
                 "tags": [
                     "Default",
@@ -1194,8 +1203,6 @@
                     "application/json"
                 ],
                 "parameters": [
-                    { "$ref": "#/parameters/accessTokenParam" },
-                    { "$ref": "#/parameters/driverIdParam" },
                     { "$ref": "#/parameters/routeEndTimeParam" },
                     { "$ref": "#/parameters/routeDurationParam" }
                 ],
@@ -1228,15 +1235,7 @@
                     "application/json"
                 ],
                 "parameters": [
-                    {
-                        "$ref": "#/parameters/accessTokenParam"
-                    },
-                    {
-                        "$ref": "#/parameters/driverIdParam"
-                    },
-                    {
-                        "$ref": "#/parameters/routeCreateParam"
-                    }
+                    { "$ref": "#/parameters/routeCreateParam" }
                 ],
                 "responses": {
                     "200": {
@@ -1255,6 +1254,19 @@
             }
         },
         "/fleet/vehicles/{vehicle_id}/dispatch/routes": {
+            "parameters": [
+                {
+                    "$ref": "#/parameters/accessTokenParam"
+                },
+                {
+                    "name": "vehicle_id",
+                    "in": "path",
+                    "required": true,
+                    "description": "ID of the vehicle with the associated routes.",
+                    "type": "integer",
+                    "format": "int64"
+                }
+            ],
             "get": {
                 "tags": [
                     "Default",
@@ -1271,8 +1283,6 @@
                     "application/json"
                 ],
                 "parameters": [
-                    { "$ref": "#/parameters/accessTokenParam" },
-                    { "$ref": "#/parameters/vehicleIdParam" },
                     { "$ref": "#/parameters/routeEndTimeParam" },
                     { "$ref": "#/parameters/routeDurationParam" }
                 ],
@@ -1305,15 +1315,7 @@
                     "application/json"
                 ],
                 "parameters": [
-                    {
-                        "$ref": "#/parameters/accessTokenParam"
-                    },
-                    {
-                        "$ref": "#/parameters/vehicleIdParam"
-                    },
-                    {
-                        "$ref": "#/parameters/routeCreateParam"
-                    }
+                    { "$ref": "#/parameters/routeCreateParam" }
                 ],
                 "responses": {
                     "200": {
@@ -2770,30 +2772,6 @@
                     }
                 }
             }
-        },
-        "driverIdParam": {
-            "name": "driver_id",
-            "in": "path",
-            "required": true,
-            "description": "The driver ID.",
-            "type": "integer",
-            "format": "int64"
-        },
-        "vehicleIdParam": {
-            "name": "vehicle_id",
-            "in": "path",
-            "required": true,
-            "description": "The vehicle ID.",
-            "type": "integer",
-            "format": "int64"
-        },
-        "routeIdParam": {
-            "name": "route_id",
-            "in": "path",
-            "required": true,
-            "description": "The route ID.",
-            "type": "integer",
-            "format": "int64"
         },
         "routeCreateParam": {
             "name": "createDispatchRouteParams",


### PR DESCRIPTION
Adding the `/v1/fleet/dispatch/routes/{route_id}/history` endpoint to our swagger documentation. 

Verified on editor.swagger.io that this documentation appears correctly with no validation errors.

This PR also fixes a new and unrelated validation error with the existing schema.json, which does not like references to `#/parameters/routeIdParam` or other path-based parameters. This appears to be a swagger bug in their latest schema parser. 