### PR TITLE
Add asset api docs

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -147,6 +147,70 @@
                 }
             }
         },
+        "/sensors/cargo": {
+            "post": {
+                "tags": [
+                    "Sensors", "Default"
+                ],
+                "summary": "/sensors/cargo",
+                "description": "Get cargo monitor status (empty / full) for requested sensors.",
+                "operationId": "get_sensors_cargo",
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/accessTokenParam"
+                    },
+                    {
+                        "$ref": "#/parameters/sensorParam"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of sensor objects containing the current cargo status reported by each sensor.",
+                        "schema": {
+                            "$ref": "#/definitions/CargoResponse"
+                        }
+                    },
+                    "default": {
+                        "description": "Unexpected error.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/sensors/door": {
+            "post": {
+                "tags": [
+                    "Sensors", "Default"
+                ],
+                "summary": "/sensors/door",
+                "description": "Get door monitor status (closed / open) for requested sensors.",
+                "operationId": "get_sensors_door",
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/accessTokenParam"
+                    },
+                    {
+                        "$ref": "#/parameters/sensorParam"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of sensor objects containing the current door status reported by each sensor.",
+                        "schema": {
+                            "$ref": "#/definitions/DoorResponse"
+                        }
+                    },
+                    "default": {
+                        "description": "Unexpected error.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/sensors/history": {
             "post": {
                 "tags": [
@@ -2092,6 +2156,76 @@
                                 "type": "integer",
                                 "description": "Currently reported relative humidity in percent, from 0-100.",
                                 "example": 53
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "CargoResponse": {
+            "type": "object",
+            "description": "Contains the current cargo status of a sensor.",
+            "properties": {
+                "groupId": {
+                    "type": "integer",
+                    "format": "int64",
+                    "example": 101
+                },
+                "sensors": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "integer",
+                                "description": "ID of the sensor.",
+                                "format": "int64",
+                                "example": 122
+                            },
+                            "name": {
+                                "type": "string",
+                                "description": "Name of the sensor.",
+                                "example": "Trailer Cargo Sensor"
+                            },
+                            "cargoEmpty": {
+                                "type": "boolean",
+                                "description": "Flag indicating whether the current cargo is empty or loaded.",
+                                "example": true
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "DoorResponse": {
+            "type": "object",
+            "description": "Contains the current door status of a sensor.",
+            "properties": {
+                "groupId": {
+                    "type": "integer",
+                    "format": "int64",
+                    "example": 101
+                },
+                "sensors": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "integer",
+                                "description": "ID of the sensor.",
+                                "format": "int64",
+                                "example": 122
+                            },
+                            "name": {
+                                "type": "string",
+                                "description": "Name of the sensor.",
+                                "example": "Trailer Door Sensor"
+                            },
+                            "doorClosed": {
+                                "type": "boolean",
+                                "description": "Flag indicating whether the current door is closed or open.",
+                                "example": true
                             }
                         }
                     }

--- a/swagger.json
+++ b/swagger.json
@@ -3254,6 +3254,11 @@
                     "description": "Asset name",
                     "example": "Trailer 123"
                 },
+                "engineHours": {
+                    "type": "integer",
+                    "description": "Engine hours",
+                    "example": "104"
+                },
                 "cable": {
                     "type": "array",
                     "description": "The cable connected to the asset",

--- a/swagger.json
+++ b/swagger.json
@@ -1796,6 +1796,42 @@
                 }
             }
         },
+        "/fleet/assets/locations": {
+            "get": {
+                "tags": [
+                    "Default", "Fleet", "Assets"
+                ],
+                "summary": "/fleet/assets/locations",
+                "description": "Fetch current locations of all assets for the group.",
+                "operationId": "GetAllAssetCurrentLocations",
+                "parameters": [
+                    { "$ref": "#/parameters/accessTokenParam" },
+                    { "$ref": "#/parameters/groupParam" }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of assets and their current locations.",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "assets": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/AssetCurrentLocationsResponse"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Unexpected error.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/fleet/assets/{asset_id}/reefer": {
             "get": {
                 "tags": [
@@ -3406,6 +3442,86 @@
                             }
                         }
                     }
+                }
+            }
+        },
+        "AssetCurrentLocationsResponse": {
+            "type": "object",
+            "description": "Basic information of an asset",
+            "required": [
+                "id"
+            ],
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "description": "Asset ID",
+                    "format": "int64",
+                    "example": 1
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Asset name",
+                    "example": "Trailer 123"
+                },
+                "engineHours": {
+                    "type": "integer",
+                    "description": "Engine hours",
+                    "example": "104"
+                },
+                "cable": {
+                    "type": "array",
+                    "description": "The cable connected to the asset",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "assetType": {
+                                "type": "string",
+                                "description": "Asset type",
+                                "example": "Reefer (Thermo King)"
+                            }
+                        }
+                    }
+                },
+                "location": {
+                    "type": "array",
+                    "description": "Current location of an asset",
+                    "items": {
+                        "$ref": "#/definitions/AssetCurrentLocation"
+                    }
+                }
+            }
+        },
+        "AssetCurrentLocation": {
+            "type": "object",
+            "description": "Current location of an asset",
+            "required": [
+                "id"
+            ],
+            "properties": {
+                "location": {
+                    "type": "string",
+                    "description": "The best effort (street,city,state) for the latitude and longitude.",
+                    "example": "525 York, San Francisco, CA"
+                },
+                "latitude": {
+                    "type": "number",
+                    "description": "The latitude of the location in degrees.",
+                    "example": "37"
+                },
+                "longitude": {
+                    "type": "number",
+                    "description": "The longitude of the location in degrees.",
+                    "example": "-122"
+                },
+                "speedMilesPerHour": {
+                    "type": "number",
+                    "description": "The speed calculated from GPS that the asset was traveling at in miles per hour.",
+                    "example": "35"
+                },
+                "timeMs": {
+                    "type": "number",
+                    "description": "Time in Unix milliseconds since epoch when the asset was at the location.",
+                    "example": "12314151"
                 }
             }
         },

--- a/swagger.json
+++ b/swagger.json
@@ -1701,7 +1701,7 @@
                 "tags": [
                     "Default", "Fleet", "Assets"
                 ],
-                "summary": "/v1/fleet/assets",
+                "summary": "/fleet/assets",
                 "description": "Fetch all of the assets for the group.",
                 "operationId": "GetAllAssets",
                 "parameters": [

--- a/swagger.json
+++ b/swagger.json
@@ -2043,6 +2043,11 @@
                                 "description": "ID of the sensor.",
                                 "example": 122
                             },
+                            "name": {
+                                "type": "string",
+                                "description": "Name of the sensor.",
+                                "example": "Freezer Temp Sensor"
+                            },
                             "ambientTemperature": {
                                 "type": "integer",
                                 "description": "Currently reported ambient temperature in millidegrees celsius.",
@@ -2077,6 +2082,11 @@
                                 "description": "ID of the sensor.",
                                 "format": "int64",
                                 "example": 122
+                            },
+                            "name": {
+                                "type": "string",
+                                "description": "Name of the sensor.",
+                                "example": "Freezer Humidity Sensor"
                             },
                             "humidity": {
                                 "type": "integer",


### PR DESCRIPTION
Update existing endpoints and add new endpoint documentations to match the changes made in /backend.

1. Add `fleet/assets/locations` endpoint that shows the current locations of all assets in the group.
2. Add `engineHours` to `/fleet/assets`
3. Add `name` to the `/sensors/*` responses
4. Add `sensors/cargo` and `/sensors/door` endpoints for the cargo and door sensors.

Tested by loading the changes into http://editor.swagger.io/ and verifying the output is what we expect.