### PR TITLE
Greg/swagger: Add swagger documentation for Tag operations

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -1760,6 +1760,48 @@
                 }
             }
         },
+        "/tags": {
+            "get": {
+                "tags": [
+                    "Default"
+                ],
+                "summary": "/tags",
+                "description": "Fetch all of the tags for a group.",
+                "operationId": "GetAllTags",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    { "$ref": "#/parameters/accessTokenParam" },
+                    { "$ref": "#/parameters/groupParam" }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of tags.",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "tags": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/Tag"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Unexpected error.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/fleet/assets": {
             "get": {
                 "tags": [
@@ -3048,6 +3090,175 @@
                     }
                 }
             }
+        },
+        "TaggedVehicle": {
+            "type": "object",
+            "required": [
+                "id",
+                "name"
+            ],
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64",
+                    "description": "The ID of the Vehicle being tagged.",
+                    "example": 123
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the vehicle being tagged.",
+                    "example": "Truck 123"
+                }
+            }
+        },
+        "TaggedAsset": {
+            "type": "object",
+            "required": [
+                "id",
+                "name"
+            ],
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64",
+                    "description": "The ID of the Asset being tagged.",
+                    "example": 456
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the Asset being tagged.",
+                    "example": "Cargo Box 456"
+                }
+            }
+        },
+        "TaggedDriver": {
+            "type": "object",
+            "required": [
+                "id",
+                "name"
+            ],
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64",
+                    "description": "The ID of the Driver being tagged.",
+                    "example": 567
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the Driver being tagged.",
+                    "example": "John Smith"
+                }
+            }
+        },
+        "TaggedMachine": {
+            "type": "object",
+            "required": [
+                "id",
+                "name"
+            ],
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64",
+                    "description": "The ID of the Machine being tagged.",
+                    "example": 789
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the Machine being tagged.",
+                    "example": "Machine 789"
+                }
+            }
+        },
+        "TaggedSensor": {
+            "type": "object",
+            "required": [
+                "id",
+                "name"
+            ],
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64",
+                    "description": "The ID of the Sensor being tagged.",
+                    "example": 345
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the Sensor being tagged.",
+                    "example": "Temperature Sensor 345"
+                }
+            }
+        },
+        "TagBase": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Name of this tag.",
+                    "example": "Broken Vehicles"
+                },
+                "vehicles": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/TaggedVehicle"
+                    },
+                    "description": "The vehicles that belong to this tag."
+                },
+                "drivers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/TaggedDriver"
+                    },
+                    "description": "The drivers that belong to this tag."
+                },
+                "assets": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/TaggedAsset"
+                    },
+                    "description": "The assets that belong to this tag."
+                },
+                "machines": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/TaggedMachine"
+                    },
+                    "description": "The machines that belong to this tag."
+                },
+                "sensors": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/TaggedSensor"
+                    },
+                    "description": "The sensors that belong to this tag."
+                }
+            }
+        },
+        "Tag": {
+            "allOf": [
+                {
+                    "type": "object",
+                    "required": [
+                        "id"
+                    ],
+                    "properties": {
+                        "id": {
+                            "type": "integer",
+                            "format": "int64",
+                            "description": "The ID of this tag.",
+                            "example": 12345
+                        }
+                    }
+                },
+                {
+                    "$ref": "#/definitions/TagBase"
+                }
+            ]
         },
         "DispatchJobCreate": {
             "type": "object",

--- a/swagger.json
+++ b/swagger.json
@@ -1875,6 +1875,39 @@
                         }
                     }
                 }
+            },
+            "put": {
+                "tags": [
+                    "Default"
+                ],
+                "summary": "/tags/{tag_id:[0-9]+}",
+                "description": "Update a tag with a new name and new members.",
+                "operationId": "updateTagById",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/tagUpdateParam"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The updated tag data.",
+                        "schema": {
+                            "$ref": "#/definitions/Tag"
+                        }
+                    },
+                    "default": {
+                        "description": "Unexpected error.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
             }
         },
         "/fleet/assets": {
@@ -4171,6 +4204,14 @@
             "in": "body",
             "schema": {
                 "$ref": "#/definitions/TagBase"
+            }
+        },
+        "tagUpdateParam": {
+            "name": "updateTagParams",
+            "required": true,
+            "in": "body",
+            "schema": {
+                "$ref": "#/definitions/Tag"
             }
         },
         "assetHistoryEndTimeParam": {

--- a/swagger.json
+++ b/swagger.json
@@ -1834,6 +1834,49 @@
                 }
             }
         },
+        "/tags/{tag_id}": {
+            "parameters": [
+                {
+                    "$ref": "#/parameters/accessTokenParam"
+                },
+                {
+                    "name": "tag_id",
+                    "in": "path",
+                    "required": true,
+                    "description": "ID of the tag.",
+                    "type": "integer",
+                    "format": "int64"
+                }
+            ],
+            "get": {
+                "tags": [
+                    "Default"
+                ],
+                "summary": "/tags/{tag_id:[0-9]+}",
+                "description": "Fetch a tag by id.",
+                "operationId": "getTagById",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The tag corresponding to tag_id.",
+                        "schema": {
+                            "$ref": "#/definitions/Tag"
+                        }
+                    },
+                    "default": {
+                        "description": "Unexpected error.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/fleet/assets": {
             "get": {
                 "tags": [

--- a/swagger.json
+++ b/swagger.json
@@ -1800,6 +1800,38 @@
                         }
                     }
                 }
+            },
+            "post": {
+                "tags": [
+                    "Default"
+                ],
+                "summary": "/tags",
+                "description": "Create a new tag for the group.",
+                "operationId": "CreateTag",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    { "$ref": "#/parameters/accessTokenParam" },
+                    { "$ref": "#/parameters/tagCreateParam" }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Newly created tag object, including the new tag ID.",
+                        "schema": {
+                            "$ref": "#/definitions/Tag"
+                        }
+                    },
+                    "default": {
+                        "description": "Unexpected error.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
             }
         },
         "/fleet/assets": {
@@ -4089,6 +4121,14 @@
             "in": "query",
             "type": "integer",
             "format": "int64"
+        },
+        "tagCreateParam": {
+            "name": "tagCreateParams",
+            "required": true,
+            "in": "body",
+            "schema": {
+                "$ref": "#/definitions/TagBase"
+            }
         },
         "assetHistoryEndTimeParam": {
             "name": "endMs",

--- a/swagger.json
+++ b/swagger.json
@@ -1908,6 +1908,31 @@
                         }
                     }
                 }
+            },
+            "delete": {
+                "tags": [
+                    "Default"
+                ],
+                "summary": "/tags/{tag_id:[0-9]+}",
+                "description": "Permanently deletes a tag.",
+                "operationId": "deleteTagById",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully deleted the tag. No response body is returned."
+                    },
+                    "default": {
+                        "description": "Unexpected error.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
             }
         },
         "/fleet/assets": {

--- a/swagger.json
+++ b/swagger.json
@@ -3224,11 +3224,10 @@
                 }
             }
         },
-        "TaggedVehicle": {
+        "TaggedVehicleBase": {
             "type": "object",
             "required": [
-                "id",
-                "name"
+                "id"
             ],
             "properties": {
                 "id": {
@@ -3236,79 +3235,123 @@
                     "format": "int64",
                     "description": "The ID of the Vehicle being tagged.",
                     "example": 123
-                },
-                "name": {
-                    "type": "string",
-                    "description": "Name of the vehicle being tagged.",
-                    "example": "Truck 123"
                 }
             }
         },
-        "TaggedAsset": {
-            "type": "object",
-            "required": [
-                "id",
-                "name"
-            ],
-            "properties": {
-                "id": {
-                    "type": "integer",
-                    "format": "int64",
-                    "description": "The ID of the Asset being tagged.",
-                    "example": 456
+        "TaggedVehicle": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/TaggedVehicleBase"
                 },
-                "name": {
-                    "type": "string",
-                    "description": "Name of the Asset being tagged.",
-                    "example": "Cargo Box 456"
+                {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the Vehicle being tagged.",
+                            "example": "Heavy Duty 123"
+                        }
+                    }
                 }
-            }
+            ]
         },
-        "TaggedDriver": {
+        "TaggedDriverBase": {
             "type": "object",
             "required": [
-                "id",
-                "name"
+                "id"
             ],
             "properties": {
                 "id": {
                     "type": "integer",
                     "format": "int64",
                     "description": "The ID of the Driver being tagged.",
-                    "example": 567
-                },
-                "name": {
-                    "type": "string",
-                    "description": "Name of the Driver being tagged.",
-                    "example": "John Smith"
+                    "example": 456
                 }
             }
         },
-        "TaggedMachine": {
+        "TaggedDriver": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/TaggedDriverBase"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the Driver being tagged.",
+                            "example": "John Smith"
+                        }
+                    }
+                }
+            ]
+        },
+        "TaggedAssetBase": {
             "type": "object",
             "required": [
-                "id",
-                "name"
+                "id"
+            ],
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64",
+                    "description": "The ID of the Asset being tagged.",
+                    "example": 789
+                }
+            }
+        },
+        "TaggedAsset": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/TaggedAssetBase"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the Asset being tagged.",
+                            "example": "Trailer 789"
+                        }
+                    }
+                }
+            ]
+        },
+        "TaggedMachineBase": {
+            "type": "object",
+            "required": [
+                "id"
             ],
             "properties": {
                 "id": {
                     "type": "integer",
                     "format": "int64",
                     "description": "The ID of the Machine being tagged.",
-                    "example": 789
-                },
-                "name": {
-                    "type": "string",
-                    "description": "Name of the Machine being tagged.",
-                    "example": "Machine 789"
+                    "example": 567
                 }
             }
         },
-        "TaggedSensor": {
+        "TaggedMachine": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/TaggedMachineBase"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the Machine being tagged.",
+                            "example": "Vibration Monitor 567"
+                        }
+                    }
+                }
+            ]
+        },
+        "TaggedSensorBase": {
             "type": "object",
             "required": [
-                "id",
-                "name"
+                "id"
             ],
             "properties": {
                 "id": {
@@ -3316,15 +3359,27 @@
                     "format": "int64",
                     "description": "The ID of the Sensor being tagged.",
                     "example": 345
-                },
-                "name": {
-                    "type": "string",
-                    "description": "Name of the Sensor being tagged.",
-                    "example": "Temperature Sensor 345"
                 }
             }
         },
-        "TagBase": {
+        "TaggedSensor": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/TaggedSensorBase"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the Sensor being tagged.",
+                            "example": "Temperature Sensor 345"
+                        }
+                    }
+                }
+            ]
+        },
+        "TagCreate": {
             "type": "object",
             "required": [
                 "name"
@@ -3338,60 +3393,93 @@
                 "vehicles": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/TaggedVehicle"
+                        "$ref": "#/definitions/TaggedVehicleBase"
                     },
                     "description": "The vehicles that belong to this tag."
                 },
                 "drivers": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/TaggedDriver"
+                        "$ref": "#/definitions/TaggedDriverBase"
                     },
                     "description": "The drivers that belong to this tag."
                 },
                 "assets": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/TaggedAsset"
+                        "$ref": "#/definitions/TaggedAssetBase"
                     },
                     "description": "The assets that belong to this tag."
                 },
                 "machines": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/TaggedMachine"
+                        "$ref": "#/definitions/TaggedMachineBase"
                     },
                     "description": "The machines that belong to this tag."
                 },
                 "sensors": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/TaggedSensor"
+                        "$ref": "#/definitions/TaggedSensorBase"
                     },
                     "description": "The sensors that belong to this tag."
                 }
             }
         },
         "Tag": {
-            "allOf": [
-                {
-                    "type": "object",
-                    "required": [
-                        "id"
-                    ],
-                    "properties": {
-                        "id": {
-                            "type": "integer",
-                            "format": "int64",
-                            "description": "The ID of this tag.",
-                            "example": 12345
-                        }
+                "type": "object",
+                "required": [
+                    "name"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "The ID of this tag.",
+                        "example": 12345
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Name of this tag.",
+                        "example": "Broken Vehicles"
+                    },
+                    "vehicles": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/TaggedVehicle"
+                        },
+                        "description": "The vehicles that belong to this tag."
+                    },
+                    "drivers": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/TaggedDriver"
+                        },
+                        "description": "The drivers that belong to this tag."
+                    },
+                    "assets": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/TaggedAsset"
+                        },
+                        "description": "The assets that belong to this tag."
+                    },
+                    "machines": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/TaggedMachine"
+                        },
+                        "description": "The machines that belong to this tag."
+                    },
+                    "sensors": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/TaggedSensor"
+                        },
+                        "description": "The sensors that belong to this tag."
                     }
-                },
-                {
-                    "$ref": "#/definitions/TagBase"
                 }
-            ]
         },
         "DispatchJobCreate": {
             "type": "object",
@@ -4228,7 +4316,7 @@
             "required": true,
             "in": "body",
             "schema": {
-                "$ref": "#/definitions/TagBase"
+                "$ref": "#/definitions/TagCreate"
             }
         },
         "tagUpdateParam": {


### PR DESCRIPTION
Updating swagger to include documentation for the 
 * `/tags`
 * `/tags/{tag_id:[0-9]+}`
endpoints. 

Tested by verifying the output at editor.swagger.io.