### PR TITLE
Jrsaunde/industrial api

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -1804,6 +1804,42 @@
                 }
             }
         },
+        "/industrial/data/{data_input_id}": {
+            "get": {
+                "tags": [
+                    "Industrial", "Default"
+                ],
+                "summary": "/industrial/data/{data_input_id:[0-9]+}",
+                "description": "Fetch datapoints from a given data input.",
+                "operationId": "GetDataInput",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    { "$ref": "#/parameters/accessTokenParam" },
+                    { "$ref": "#/parameters/dataInputIdParam"},
+                    { "$ref": "#/parameters/dataInputStartTimeParam"},
+                    { "$ref": "#/parameters/dataInputEndTimeParam"}
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Returns datapoints for the given data input",
+                        "schema": {
+                            "$ref": "#/definitions/DataInputHistoryResponse"
+                        }
+                    },
+                    "default": {
+                        "description": "Unexpected error.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/tags": {
             "get": {
                 "tags": [
@@ -4432,6 +4468,15 @@
             "description": "ID of the asset",
             "type": "integer",
             "format": "int64"
+        },
+        "dataInputIdParam": {
+            "name": "data_input_id",
+            "in": "path",
+            "required": true,
+            "description": "ID of the data input",
+            "type": "integer",
+            "format": "int64"
+        },
         "dataInputEndTimeParam": {
             "name": "endMs",
             "description": "Timestamp in unix milliseconds representing the end of the period to fetch, inclusive. Used in combination with startMs. Defaults to nowMs.",

--- a/swagger.json
+++ b/swagger.json
@@ -30,8 +30,8 @@
             "description": "Access to fleet data"
         },
         {
-            "name": "Machines",
-            "description": "Access to machine data"
+            "name": "Industrial",
+            "description": "Access to industrial data"
         },
         {
             "name": "Sensors",
@@ -1662,7 +1662,7 @@
         "/machines/list": {
             "post": {
                 "tags": [
-                    "Machines", "Default"
+                    "Industrial", "Default"
                 ],
                 "summary": "/machines/list",
                 "description": "Get machine objects. This method returns a list of the machine objects in the Samsara Cloud and information about them.",
@@ -1702,7 +1702,7 @@
         "/machines/history": {
             "post": {
                 "tags": [
-                    "Machines", "Default"
+                    "Industrial", "Default"
                 ],
                 "summary": "/machines/history",
                 "description": "Get historical data for machine objects. This method returns a set of historical data for all machines in a group",
@@ -1749,6 +1749,50 @@
                         "description": "List of machine results objects, each containing a time and a datapoint.",
                         "schema": {
                             "$ref": "#/definitions/MachineHistoryResponse"
+                        }
+                    },
+                    "default": {
+                        "description": "Unexpected error.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/industrial/data": {
+            "get": {
+                "tags": [
+                    "Industrial", "Default"
+                ],
+                "summary": "/industrial/data",
+                "description": "Fetch all of the data inputs for a group.",
+                "operationId": "GetAllDataInputs",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    { "$ref": "#/parameters/accessTokenParam" },
+                    { "$ref": "#/parameters/groupParam" },
+                    { "$ref": "#/parameters/dataInputStartTimeParam"},
+                    { "$ref": "#/parameters/dataInputEndTimeParam"}
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of data inputs.",
+                        "schema": {
+                            "type": "object",
+                            "properties":{
+                                "dataInputs":{
+                                    "type": "array",
+                                    "items":{
+                                        "$ref": "#/definitions/DataInputHistoryResponse"
+                                    }
+                                }
+                            }
                         }
                     },
                     "default": {
@@ -3760,6 +3804,44 @@
                 }
             }
         },
+        "DataInputHistoryResponse": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64",
+                    "description":"The ID of this data input",
+                    "example": 12345
+                },
+                "name": {
+                    "type": "string",
+                    "description":"Name of this data input",
+                    "example":"Pump Flow"
+                },
+                "points": {
+                    "type": "array",
+                    "description": "Data points from this data input",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "timeMs":{
+                                "type":"integer",
+                                "format": "int64",
+                                "example": 1453449599999
+                            },
+                            "value":{
+                                "type":"number",
+                                "format": "float",
+                                "example": 12.332
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "Machine": {
             "type": "object",
             "description": "Contains information about a machine.",
@@ -4348,6 +4430,21 @@
             "in": "path",
             "required": true,
             "description": "ID of the asset",
+            "type": "integer",
+            "format": "int64"
+        "dataInputEndTimeParam": {
+            "name": "endMs",
+            "description": "Timestamp in unix milliseconds representing the end of the period to fetch, inclusive. Used in combination with startMs. Defaults to nowMs.",
+            "required": false,
+            "in": "query",
+            "type": "integer",
+            "format": "int64"
+        },
+        "dataInputStartTimeParam": {
+            "name": "startMs",
+            "description": "Timestamp in unix milliseconds representing the start of the period to fetch, inclusive. Used in combination with endMs. defaults to nowMs.",
+            "required": false,
+            "in": "query",
             "type": "integer",
             "format": "int64"
         }


### PR DESCRIPTION
This adds documentation for two new api endpoints:

/industrial/data => list all data inputs in a group (and optional historical datapoints):
<img width="1441" alt="screen shot 2018-06-11 at 7 36 04 pm" src="https://user-images.githubusercontent.com/3857768/41267433-5240ba32-6db0-11e8-8b50-03dc8fa26814.png">


/industrial/data/{data_input_id} =>  fetch datapoints for a dataInput
<img width="1439" alt="screen shot 2018-06-11 at 7 36 25 pm" src="https://user-images.githubusercontent.com/3857768/41267428-4f04879a-6db0-11e8-94ac-0d9e78e32a3c.png">


This also moves the machine endpoints under the industrial tag, put doesn't change the path, so current users can still use the API:

<img width="1447" alt="screen shot 2018-06-11 at 7 37 06 pm" src="https://user-images.githubusercontent.com/3857768/41267418-445ddb02-6db0-11e8-97e4-fce5aa665fda.png">