### PR TITLE
swagger: updated text of drivers/summary response

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -2819,7 +2819,7 @@
         "DriversSummaryResponse": {
           "type": "object",
           "properties": {
-            "summaries": {
+            "Summaries": {
               "type": "array",
               "items": {
                 "type": "object",


### PR DESCRIPTION
This change addresses Jira issue API-55; it updates the API documentation to reflect what is actually returned when calling the /fleet/drivers/summary endpoint