### PR TITLE
Greg/swagger: Update /fleet/drivers/{driver_id} response to include currentVehicleId

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -518,7 +518,7 @@
                     "200": {
                         "description": "All drivers in the group.",
                         "schema": {
-                            "$ref": "#/definitions/DriversRespose"
+                            "$ref": "#/definitions/DriversResponse"
                         }
                     },
                     "default": {
@@ -2821,7 +2821,7 @@
                 }
             ]
         },
-        "DriversRespose": {
+        "DriversResponse": {
             "type": "object",
             "properties": {
                 "drivers": {

--- a/swagger.json
+++ b/swagger.json
@@ -595,7 +595,7 @@
                     "200": {
                         "description": "Returns the driver for the given driver_id.",
                         "schema": {
-                            "$ref": "#/definitions/Driver"
+                            "$ref": "#/definitions/CurrentDriver"
                         }
                     },
                     "default": {
@@ -731,7 +731,7 @@
                     "200": {
                         "description": "Returns the reactivated driver, which is now available at /fleet/drivers/{driver_id}.",
                         "schema": {
-                            "$ref": "#/definitions/Driver"
+                            "$ref": "#/definitions/CurrentDriver"
                         }
                     },
                     "default": {
@@ -2788,7 +2788,36 @@
                     }
                 },
                 {
+                    "type": "object",
+                    "properties": {
+                        "currentVehicleId": {
+                            "type": "integer",
+                            "format": "int64",
+                            "description": "ID of the vehicle that this driver is currently assigned to. Omitted if there is no current vehicle assignment for this driver.",
+                            "example": 879
+                        }
+                    }
+                },
+                {
                     "$ref": "#/definitions/DriverBase"
+                }
+            ]
+        },
+        "CurrentDriver": {
+            "allOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "currentVehicleId": {
+                            "type": "integer",
+                            "format": "int64",
+                            "description": "ID of the vehicle that this driver is currently assigned to. Omitted if there is no current vehicle assignment for this driver.",
+                            "example": 879
+                        }
+                    }
+                },
+                {
+                    "$ref": "#/definitions/Driver"
                 }
             ]
         },


### PR DESCRIPTION
Updating our `/fleet/drivers/{driver_id}` endpoint to include the new `currentVehicleId` field, which indicates the vehicle ID that the driver is currently assigned to. 