### PR TITLE
swagger: Add scheduled_departure_time_ms to DispatchJobCreate

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -3823,6 +3823,12 @@
                     "description": "The time at which the assigned driver is scheduled to arrive at the job destination.",
                     "example": 1462881998034
                 },
+                "scheduled_departure_time_ms": {
+                    "type": "integer",
+                    "format": "int64",
+                    "description": "The time at which the assigned driver is scheduled to depart from the job destination.",
+                    "example": 1462881998034
+                },
                 "notes": {
                     "type": "string",
                     "description": "Notes regarding the details of this job.",


### PR DESCRIPTION
We're exposing scheduled departure time info as is on GET/POST
endpoints that contain dispatch job info.

Verified via http://editor.swagger.io/ that scheduled departure time info appears on the following endpoints -

```
/fleet/dispatch/routes (GET, POST)
/fleet/dispatch/routes/job_updates (GET)
/fleet/dispatch/routes/{route_id} (GET, PUT)
/fleet/dispatch/routes/{route_id}/history (GET)
/fleet/drivers/{driver_id}/dispatch/routes (GET, POST)
/fleet/vehicles/{vehicle_id}/dispatch/routes (GET, POST)
```