### PR TITLE
swagger: Add estimated_arrival_ms to DispatchJobResponse

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -3990,6 +3990,12 @@
                             "format": "int64",
                             "description": "The time at which the job was marked skipped.",
                             "example": 1462881998034
+                        },
+                        "estimated_arrival_ms": {
+                            "type": "integer",
+                            "format": "int64",
+                            "description": "The time at which the assigned driver is estimated to arrive at the job destination. Only valid for en-route jobs.",
+                            "example": 1462881998034
                         }
                     }
                 },


### PR DESCRIPTION
We're exposing `estimated_arrival_ms` on GET/PUT endpoints related to dispatch jobs.

This is only applicable to en-route jobs (since null responses will be automatically omitted)

This PR is related to https://github.com/samsara-dev/backend/pull/12598

Verified via http://editor.swagger.io/ that ETA info appears on the following endpoints -

```
/fleet/dispatch/routes (GET)
/fleet/dispatch/routes/job_updates (GET)
/fleet/dispatch/routes/{route_id} (GET, PUT)
/fleet/dispatch/routes/{route_id}/history (GET)
/fleet/drivers/{driver_id}/dispatch/routes (GET)
/fleet/vehicles/{vehicle_id}/dispatch/routes (GET)
```
