### PR TITLE
swagger: add vehicleId to driver docs; correct snake to camel case

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -5078,30 +5078,30 @@
                 "$ref": "#/definitions/DocumentField"
             }
         },
-        "Document": {            
+        "Document": {
             "type": "object",
             "required": [
-                "driver_id",
-                "driver_created_at_ms",
-                "document_type",
-                "dispatch_job_id",
-                "notes",
-                "fields"
+              "driverId",
+              "driverCreatedAtMs",
+              "documentType",
+              "dispatchJobId",
+              "notes",
+              "fields"
             ],
             "properties": {
-                "driver_id": {
+                "driverId": {
                     "type": "integer",
                     "format": "int64",
-                    "description":  "ID of the driver that submitted this document.",
+                    "description": "ID of the driver that submitted this document.",
                     "example": 555
                 },
-                "driver_created_at_ms": {
+                "driverCreatedAtMs": {
                     "type": "integer",
                     "format": "int64",
                     "description": "The time in Unix epoch milliseconds that the document was created by the driver.",
                     "example": 1462881998034
                 },
-                "document_type": {
+                "documentType": {
                     "type": "string",
                     "description": "Descriptive name of this type of document.",
                     "example": "Fuel Receipt"
@@ -5111,6 +5111,12 @@
                     "format": "int64",
                     "description": "ID of the Samsara dispatch job.",
                     "example": 773
+                },
+                "vehicleId": {
+                    "type": "integer",
+                    "format": "int64",
+                    "description": "VehicleID of the driver at document creation.",
+                    "example": 222
                 },
                 "notes": {
                     "type": "string",


### PR DESCRIPTION
Added `vehicleId` to driver documents

Incorrectly showed driver doc API response as snake case in swagger, and corrected it here to show the response in camel case instead

<img width="1265" alt="screen shot 2018-09-07 at 12 45 27 pm" src="https://user-images.githubusercontent.com/34557317/45245845-09e9af80-b2b3-11e8-94a8-677ea56c4782.png">
