### PR TITLE
swagger dispatch: actual times to route, fleet viewer token to job

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -4219,6 +4219,11 @@
                             "description": "ID of the vehicle used for the dispatch job.",
                             "example": 112
                         },
+                        "fleet_viewer_url": {
+                            "type": "string",
+                            "description": "Fleet viewer url of the dispatch job.",
+                            "example": "https://cloud.samsara.com/fleet/viewer/job/fleet_viewer_token"
+                        },
                         "job_state": {
                             "$ref": "#/definitions/jobStatus"
                         },
@@ -4280,6 +4285,18 @@
                     "format": "int64",
                     "description":  "ID of the driver assigned to the dispatch route. Note that driver_id and vehicle_id are mutually exclusive. If neither is specified, then the route is unassigned.",
                     "example": 555
+                },
+                "actual_start_ms": {
+                    "type": "integer",
+                    "format": "int64",
+                    "description": "The time in Unix epoch milliseconds that the route actually started.",
+                    "example": 1462882098000
+                },
+                "actual_end_ms": {
+                    "type": "integer",
+                    "format": "int64",
+                    "description": "The time in Unix epoch milliseconds that the route actually ended.",
+                    "example": 1462882101000
                 },
                 "scheduled_start_ms": {
                     "type": "integer",


### PR DESCRIPTION
Add `actual_start_ms` and `actual_end_ms` to `DispatchRoute` and `fleet_viewer_token` to `DispatchJob`

![2018-09-11 dispatch route api actual times](https://user-images.githubusercontent.com/34557317/45391339-6ad8f680-b5d7-11e8-9d6e-f70b5f64d445.gif)

