### PR TITLE
swagger: add destinationAddressId to DispatchJobs

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -4280,6 +4280,12 @@
                             "format": "int64",
                             "description": "The time at which the assigned driver is estimated to arrive at the job destination. Only valid for en-route jobs.",
                             "example": 1462881998034
+                        },
+                        "destination_address_id": {
+                            "type": "integer",
+                            "format": "int64",
+                            "description": "ID of the job destination associated with an address book entry.",
+                            "example": 67890
                         }
                     }
                 },


### PR DESCRIPTION
Tested in Swagger editor:
![20181002_dispatchjob-destinationaddressid](https://user-images.githubusercontent.com/4021754/46383669-651a8200-c666-11e8-983e-bd70836fadeb.gif)
