### PR TITLE
swagger: add vehicleId to safety score harsh events

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -4955,6 +4955,11 @@
             "type": "object",
             "description": "List of harsh events",
             "properties": {
+                "vehicleId": {
+                    "type": "integer",
+                    "description": "Vehicle associated with the harsh event",
+                    "example": 212014918086169
+                },
                 "timestampMs": {
                     "type": "integer",
                     "description": "Timestamp that the harsh event occurred in Unix milliseconds since epoch",


### PR DESCRIPTION
- adds `vehicleId` as a field on the safety score harsh event
Relevant PR: https://github.com/samsara-dev/backend/pull/14833