### PR TITLE
Kelsey/swagger ddocs create

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -5200,63 +5200,114 @@
         },
         "DocumentFields": {
             "type": "array",
+            "example": [
+                {"label": "Photos", "valueType": "ValueType_Photo", "photoValue": []},
+                {"label": "Gallons", "valueType": "ValueType_Number", "numberValue": 12.34 },
+                {"label": "City", "valueType": "ValueType_String", "stringValue": "San Francisco, CA" }
+            ],
             "items": {
                 "$ref": "#/definitions/DocumentField"
             }
         },
-        "Document": {
-            "type": "object",
-            "required": [
-              "driverId",
-              "driverCreatedAtMs",
-              "documentType",
-              "dispatchJobId",
-              "notes",
-              "fields"
+        "DocumentFieldCreates": {
+            "type": "array",
+            "example": [
+                {"valueType": "ValueType_Photo", "photoValue": []},
+                {"valueType": "ValueType_Number", "numberValue": 12.34 },
+                {"valueType": "ValueType_String", "stringValue": "San Francisco, CA" }
             ],
+            "items": {
+                "$ref": "#/definitions/DocumentFieldCreate"
+            }
+        },
+        "DocumentBase": {
+            "type": "object",
             "properties": {
-                "driverId": {
-                    "type": "integer",
-                    "format": "int64",
-                    "description": "ID of the driver that submitted this document.",
-                    "example": 555
-                },
-                "driverCreatedAtMs": {
-                    "type": "integer",
-                    "format": "int64",
-                    "description": "The time in Unix epoch milliseconds that the document was created by the driver.",
-                    "example": 1462881998034
-                },
-                "documentType": {
-                    "type": "string",
-                    "description": "Descriptive name of this type of document.",
-                    "example": "Fuel Receipt"
-                },
                 "dispatchJobId": {
                     "type": "integer",
                     "format": "int64",
-                    "description": "ID of the Samsara dispatch job that the document was submitted for.",
+                    "description": "ID of the Samsara dispatch job for which the document is submitted",
                     "example": 773
-                },
-                "vehicleId": {
-                    "type": "integer",
-                    "format": "int64",
-                    "description": "VehicleID of the driver at document creation.",
-                    "example": 222
                 },
                 "notes": {
                     "type": "string",
                     "description": "Notes submitted with this document.",
                     "example": "Fueled up before delivery."
-                },
-                "fields": {
-                    "description": "The fields associated with this document.",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/DocumentFields"
-                    }
                 }
             }
+        },
+        "Document": {
+            "allOf": [
+                {
+                    "type": "object",
+                    "required": [
+                        "driverId",
+                        "driverCreatedAtMs",
+                        "documentType",
+                        "fields"
+                    ],
+                    "properties": {
+                        "driverId": {
+                            "type": "integer",
+                            "format": "int64",
+                            "description": "ID of the driver for whom the document is submitted",
+                            "example": 555
+                        },
+                        "driverCreatedAtMs": {
+                            "type": "integer",
+                            "format": "int64",
+                            "description": "The time in Unix epoch milliseconds that the document is created.",
+                            "example": 1462881998034
+                        },
+                        "documentType": {
+                            "type": "string",
+                            "description": "Descriptive name of this type of document.",
+                            "example": "Fuel Receipt"
+                        },
+                        "vehicleId": {
+                            "type": "integer",
+                            "format": "int64",
+                            "description": "VehicleID of the driver at document creation.",
+                            "example": 222
+                        },
+                        "fields": {
+                            "description": "The fields associated with this document.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/DocumentFields"
+                            }
+                        }
+                    }
+                },
+                { "$ref": "#/definitions/DocumentBase"}
+            ]
+        },
+        "DocumentCreate": {
+            "allOf": [
+                {
+                    "type": "object",
+                    "description": "Arguments to create a document.",
+                    "required": [
+                        "documentTypeUuid",
+                        "fields"
+                    ],
+                    "properties": {
+                        "documentTypeUuid": {
+                            "type": "string",
+                            "description": "Universally unique identifier for the document type this document is being created for.",
+                            "example": "4aff772c-a7bb-45e6-8e41-6a53e34feb83"
+                        },
+                        "fields": {
+                            "description": "List of fields should match the document type’s list of field types in the correct order. In other words, a field's valueType and value (i.e. only one of: stringValue, numberValue, or photoValue) at index _i_ should match with the document field type’s valueType at index _i_.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/DocumentFieldCreates"
+                            }
+                        }
+                    }
+                },
+                { "$ref": "#/definitions/DocumentBase"}
+            ]
         },
         "Documents": {
             "type": "array",

--- a/swagger.json
+++ b/swagger.json
@@ -5138,23 +5138,34 @@
             }
         },
         "DocumentField": {
+            "allOf": [
+                {
+                    "type": "object",
+                    "required": [
+                        "label"
+                    ],
+                    "description": "A field of a document. A field can be a string type, number type, or photo type, which can be identified from its valueType. Between stringValue, numberValue, and photoValue, only one can exist for a single document field depending on the valueType.",
+                    "properties": {
+                        "label": {
+                            "type": "string",
+                            "description": "Descriptive name of this field.",
+                            "example": "Fuel Cost ($)"
+                        },
+                        "value": {
+                            "description":  "DEPRECATED: Please use stringValue, numberValue, or photoValue instead. Value of this field. Depending on what kind of field it is, this may be one of the following: an array of image urls, a float, an integer, or a string.",
+                            "example": 23.45
+                        }
+                    }
+                },
+                { "$ref": "#/definitions/DocumentFieldCreate"}
+            ]
+        },
+        "DocumentFieldCreate": {
             "type": "object",
             "required": [
-                "label",
                 "valueType"
             ],
-            "description": "A field of a document. A field can be a string type, number type, or photo type, which you can identify from its valueType. Between stringValue, numberValue, and photoValue, only one can exist for a single document field depending on the valueType.",
             "properties": {
-                "label": {
-                    "type": "string",
-                    "description": "Descriptive name of this field.",
-                    "example": "Fuel Cost ($)"
-                },
-                "value": {
-                    "description":  "DEPRECATED: Please use stringValue, numberValue, or photoValue instead. Value of this field. Depending on what kind of field it is, this may be one of the following: an array of image urls, a float, an integer, or a string.",
-                    "example": 23.45,
-                    "deprecated": true
-                },
                 "valueType": {
                     "type": "string",
                     "description": "Determines the type of this field and what type of value this field has. It should be either ValueType_Number, ValueType_String, or ValueType_Photo.",

--- a/swagger.json
+++ b/swagger.json
@@ -1876,6 +1876,53 @@
                 }
             }
         },
+        "/fleet/drivers/{driver_id}/documents": {
+            "parameters": [
+                {
+                    "$ref": "#/parameters/accessTokenParam"
+                },
+                {
+                    "name": "driver_id",
+                    "in": "path",
+                    "required": true,
+                    "description": "ID of the driver for whom the document is created.",
+                    "type": "integer",
+                    "format": "int64"
+                }
+            ],
+            "post": {
+                "tags": [
+                    "Default",
+                    "Fleet"
+                ],
+                "summary": "/fleet/drivers/{driver_id:[0-9]+}/documents",
+                "description": "Create a driver document for the given driver.",
+                "operationId": "createDriverDocument",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    { "$ref": "#/parameters/documentCreateParam" }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Returns the created document.",
+                        "schema": {
+                            "$ref": "#/definitions/Document"
+                        }
+                    },
+                    "default": {
+                        "description": "Unexpected error.",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/machines/list": {
             "post": {
                 "tags": [
@@ -5644,6 +5691,15 @@
             "in": "query",
             "type": "integer",
             "format": "int64"
+        },
+        "documentCreateParam": {
+            "name": "createDocumentParams",
+            "description": "To create a document for a given document type, the document type's uuid needs to be passed in to documentTypeUuid. The list of fields passed in should match the document type’s list of field types in the correct order. In other words, a field's valueType and value (i.e. only one of: stringValue, numberValue, or photoValue) at index _i_ should match with the document field type’s valueType at index _i_.",
+            "required": true,
+            "in": "body",
+            "schema": {
+                "$ref": "#/definitions/DocumentCreate"
+            }
         },
         "safetyScoreStartMsParam": {
             "name": "startMs",


### PR DESCRIPTION
I added the POST document endpoint to swagger documentation.

In the process, I also rearranged DocumentField to be DocumentField and DocumentFieldCreate, where DocumentField refs DocumentFieldCreate, since all properties in DocumentFieldCreate are in DocumentField as well.

I rearranged Document to be Document, DocumentBase, and DocumentCreate, where Document and DocumentCreate ref DocumentBase (which has their common properties).

I hardcoded the example for DocumentFields and DocumentCreate (whose fields don't have labels), since the default examples for those will show fields with stringValue, numberValue, AND photoValue, but a single field should only actually have one of those values.

POST document:
![image](https://user-images.githubusercontent.com/10555857/46704006-fa28f800-cbdd-11e8-8ebe-75cca5111d8c.png)
![image](https://user-images.githubusercontent.com/10555857/46704014-01500600-cbde-11e8-86ce-4ba9c2fd64b7.png)
