### PR TITLE
go swagger: Fix snake case driver create params

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -3402,13 +3402,13 @@
                     "type": "integer",
                     "description": "0 indicating midnight-to-midnight ELD driving hours, 12 to indicate noon-to-noon driving hours."
                 },
-                "vehicle_id": {
+                "vehicleId": {
                     "type": "integer",
                     "format": "int64",
                     "description":  "ID of the vehicle assigned to the driver for static vehicle assignments. (uncommon).",
                     "example": 444
                 },
-                "group_id": {
+                "groupId": {
                     "type": "integer",
                     "format": "int64",
                     "description": "ID of the group if the organization has multiple groups (uncommon).",


### PR DESCRIPTION
Updating the swagger documentation to reflect the proper variable names
for vehicleId and groupId on the driver create endpoint.

Fixes INTL-327