### PR TITLE
swagger: correct type for fuelLevelPercent

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -2936,7 +2936,7 @@
                     "example": 1500
                 },
                 "fuelLevelPercent": {
-                    "type": "float",
+                    "type": "number",
                     "format": "float64",
                     "description": "The fuel level of the vehicle as a percentage. (0.0 to 1.0)",
                     "example": 0.3


### PR DESCRIPTION
"float" should be "number" for the type of vehicle fuelLevelPercent.