### PR TITLE
Add onDutyMs and driveMs to fleet/drivers/hos_daily_logs

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -3600,6 +3600,18 @@
                     "description": "Hours spent on duty or driving, rounded to two decimal places.",
                     "example": 5.40
                   },
+                  "onDutyMs": {
+                    "type": "number",
+                    "format": "int64",
+                    "description": "Duration in milliseconds that driver was on duty during the requested time range.",
+                    "example": 21600000
+                  },
+                  "driveMs": {
+                    "type": "number",
+                    "format": "int64",
+                    "description": "Duration in milliseconds that driver was driving during the requested time range.",
+                    "example": 21600000
+                  },
                   "certified": {
                     "type": "boolean",
                     "description": "Whether this HOS day chart was certified by the driver."


### PR DESCRIPTION
This Adds `onDutyMs` and `driveMs` as response parameters to the `fleet/drivers/hos_daily_logs` endpoint.