### PR TITLE
swagger: add trailerId to DvirListResponse definition

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -3802,6 +3802,11 @@
                     "description": "The name of the trailer which was part of the DVIR.",
                     "example": "Storer's Trailer 19"
                   },
+                  "trailerId": {
+                    "type": "integer",
+                    "description": "The id of the trailer which was part of the DVIR.",
+                    "example": 19
+                  },
                   "trailerDefects": {
                     "type": "array",
                     "description": "Defects registered for the trailer which was part of the DVIR.",


### PR DESCRIPTION
trailerId is now returned when the DVIR in question is tied to a trailer object. Updated docs to include trailerId in the example response from dvir list endpoint. 