### PR TITLE
swagger: add tags to addresses

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -2667,7 +2667,7 @@
                     "Default", "Fleet"
                 ],
                 "summary": "/addresses/{addressId}",
-                "description": "Update the name, formatted address, or geofence of an address.",
+                "description": "Update the name, formatted address, geofence, notes, or tag and contact Ids for an address. The set of tags or contacts associated with this address will be updated to exactly match the list of IDs passed in. To remove all tags or contacts from an address, pass an empty list; to remove notes, pass an empty string.",
                 "operationId": "UpdateOrganizationAddress",
                 "parameters": [
                     { "$ref": "#/parameters/accessTokenParam" },
@@ -2822,6 +2822,12 @@
                 },
                 "notes": {
                     "$ref": "#/definitions/AddressNotes"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/TagMetadata"
+                    }
                 }
             }
         },
@@ -4586,6 +4592,35 @@
                     }
                 }
         },
+        "TagMetadata": {
+            "type": "object",
+            "required": [
+                "id",
+                "name"
+            ],
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64",
+                    "description": "The ID of this tag.",
+                    "example": 12345
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of this tag.",
+                    "example": "Broken Vehicles"
+                }
+            }
+        },
+        "TagIds": {
+            "type": "array",
+            "description": "A list of tag IDs.",
+            "items": {
+                "type": "number",
+                "format": "int64",
+                "example": 123
+            }
+        },
         "DispatchJobCreate": {
             "type": "object",
             "required": [
@@ -5961,6 +5996,9 @@
                                 },
                                 "notes": {
                                     "$ref": "#/definitions/AddressNotes"
+                                },
+                                "tagIds": {
+                                    "$ref": "#/definitions/TagIds"
                                 }
                             }
                         }
@@ -5994,6 +6032,9 @@
                     },
                     "notes": {
                         "$ref": "#/definitions/AddressNotes"
+                    },
+                    "tagIds": {
+                        "$ref": "#/definitions/TagIds"
                     }
                 }
             }


### PR DESCRIPTION
Adds tag ID parameters to address POST and PATCH, and adds tags to responses for address single and multiple GET. 

For discussion: 
~Does it make sense to include the entire tag object in the GET responses? a ton of data comes back in the list of tags, because it's returning every entity under every tag. Would it be better to return just the list of tag IDs?~ Outcome: we'll be returning just the name & id of each tag. 

[Sandbox here.](http://rebilly.github.io/ReDoc/?url=https://raw.githubusercontent.com/samsarahq/api-docs/6ea0894f5a1075a466a42596f39783d642a673a0/swagger.json#operation/AddOrganizationAddresses) If you click into the GET /addresses endpoint you can see an example tags response in context.

To be landed once this functionality is fully implemented.