### PR TITLE
api docs: Add info about route start location validation

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -4622,7 +4622,7 @@
                 "destination_address_id": {
                     "type": "integer",
                     "format": "int64",
-                    "description": "ID of the job destination associated with an address book entry. Optional if valid values are provided for destination name, address, latitude and longitude. If a valid destination address ID is provided, address/latitude/longitude will be used from the address book entry. Name of the address book entry will only be used if the destination name is not provided.",
+                    "description": "ID of the job destination associated with an address book entry. Optional if valid values are provided for destination address or latitude/longitude. If a valid destination address ID is provided, address/latitude/longitude will be used from the address book entry. Name of the address book entry will only be used if the destination name is not provided.",
                     "example": 67890
                 },
                 "destination_lat": {
@@ -4755,9 +4755,7 @@
             "required": [
                 "name",
                 "scheduled_start_ms",
-                "scheduled_end_ms",
-                "start_location_lat",
-                "start_location_lng"
+                "scheduled_end_ms"
             ],
             "properties": {
                 "vehicle_id": {
@@ -4809,24 +4807,30 @@
                 },
                 "start_location_name": {
                     "type": "string",
-                    "description": "The name of the route's starting location.",
+                    "description": "The name of the route's starting location. If provided, it will take precedence over the name of the address book entry.",
                     "example": "ACME Inc. Philadelphia HQ"
                 },
                 "start_location_address": {
                     "type": "string",
-                    "description": "The address of the route's starting location, as it would be recognized if provided to maps.google.com",
+                    "description": "The address of the route's starting location, as it would be recognized if provided to maps.google.com. Optional if a valid start location address ID or start location latitude/longitude pair is provided.",
                     "example": "123 Main St, Philadelphia, PA 19106"
+                },
+                "start_location_address_id": {
+                    "type": "integer",
+                    "format": "int64",
+                    "description": "ID of the start location associated with an address book entry. Optional if valid values are provided for start location address or latitude/longitude. If a valid start location address ID is provided, address/latitude/longitude will be used from the address book entry. Name of the address book entry will only be used if the start location name is not provided.",
+                    "example": 67890
                 },
                 "start_location_lat": {
                     "type": "number",
                     "format": "double",
-                    "description": "Latitude of the destination in decimal degrees.",
+                    "description": "Latitude of the start location in decimal degrees. Optional if a valid start location address ID or start location address is provided.",
                     "example": 123.456
                 },
                 "start_location_lng": {
                     "type": "number",
                     "format": "double",
-                    "description": "Latitude of the destination in decimal degrees.",
+                    "description": "Longitude of the start location in decimal degrees. Optional if a valid start location address ID or start location address is provided.",
                     "example": 37.459
                 }
             }


### PR DESCRIPTION
Adds info about route start location address IDs, as well as when different fields associated with route start location addresses are optional.

Also updates a minor issue where we incorrectly indicated when job
destination address IDs are optional.

As seen on editor.swagger.io - 

Routes POST - 

![image](https://user-images.githubusercontent.com/2613128/49322469-c1621c80-f4c4-11e8-8b31-67f56422abc3.png)

Routes PUT -

![image](https://user-images.githubusercontent.com/2613128/49322476-d0e16580-f4c4-11e8-8b56-b27d40d6aff8.png)
