### PR TITLE
Fleet Driver Settings endpoint updates

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -747,7 +747,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Returns the successfully created the driver.",
+                        "description": "Returns the successfully created driver.",
                         "schema": {
                             "$ref": "#/definitions/Driver"
                         }

--- a/swagger.json
+++ b/swagger.json
@@ -4187,28 +4187,24 @@
                 "drivers": {
                     "type": "array",
                     "items": {
-                        "type": "object",
-                        "properties": {
-                            "id": {
-                                "type": "integer",
-                                "format": "int64",
-                                "description": "ID of the driver.",
-                                "example": 444
+                        "allOf": [
+                            {
+                                "$ref": "#/definitions/Driver"
                             },
-                            "name": {
-                                "type": "string",
-                                "description": "Name of the driver.",
-                                "example": "Fred Jacobs"
-                            },
-                            "externalIds" : {
-                              "type": "object",
-                              "description": "Dictionary of external IDs (string key-value pairs)",
-                              "additionalProperties": {
-                                "type": "string"
-                              },
-                              "example": {"payrollId": "123", "internalDriverId": "250020"}
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "externalIds" : {
+                                    "type": "object",
+                                    "description": "Dictionary of external IDs (string key-value pairs)",
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "example": {"payrollId": "123", "internalDriverId": "250020"}
+                                    }
+                                }
                             }
-                        }
+                        ]
                     }
                 }
             }

--- a/swagger.json
+++ b/swagger.json
@@ -4076,7 +4076,7 @@
                             "type": "integer",
                             "format": "int64",
                             "description": "ID of the driver.",
-                            "example": 556
+                            "example": 719
                         },
                         "isDeactivated": {
                             "type": "boolean",

--- a/swagger.json
+++ b/swagger.json
@@ -4042,6 +4042,69 @@
                     "description": "ID of the group if the organization has multiple groups (uncommon).",
                     "example": 101
                 },
+                "timezone": {
+                    "type": "string",
+                    "description": "Timezone used by the driver for daily logs (e.g. America/New_York, Europe/Paris), if different from the organization default.",
+                    "example": "America/New_York"
+                },
+                "carrierNameOverride": {
+                    "type": "string",
+                    "description": "Carrier’s name, if different from the organization default.",
+                    "example": "Samsara"
+                },
+                "mainOfficeAddressOverride": {
+                    "type": "string",
+                    "description": "Carrier’s office address, if different from the organization default.",
+                    "example": "444 De Haro St, San Francisco"
+                },
+                "carrierUsDotNumberOverride": {
+                    "type": "integer",
+                    "description": "Carrier’s US DOT number (max: 999999999), if different from the organization default.",
+                    "example": "999999999"
+                },
+                "tags": {
+                    "type": "array",
+                    "description": "An array of tags that the driver belongs to.",
+                    "items": {
+                        "type": "string",
+                        "example": "R05_004"
+                    }
+                },
+                "notes": {
+                    "type": "string",
+                    "description": "Notes about the driver.",
+                    "example": "Driver operates in the West."
+                },
+                "vehicleSelectionTags": {
+                    "type": "string",
+                    "description": "Tag containing vehicles a driver may select from in the Driver app.",
+                    "example": "West"
+                },
+                "caOffDutyDeferralExemptionEnabled": {
+                    "type": "boolean",
+                    "description": "Flag indicating this driver may select Off Duty Deferal Exemptions in Canada. (default: false)",
+                    "example": false
+                },
+                "caAdverseDrivingExemptionEnabled": {
+                    "type": "boolean",
+                    "description": "Flag indicating this driver may select Adverse Driving Exemptions in Canada. (default: false)",
+                    "example": false
+                },
+                "localeOverride": {
+                    "type": "string",
+                    "description": "The customer locale the driver belongs to, if different from the organization default (e.g. “us”, “ca”, “gb”, “fr”).",
+                    "example": "us"
+                },
+                "languageOverride": {
+                    "type": "string",
+                    "description": "Language presented to the driver by default, if different from the organization default (e.g. “en-us”, “en-ca”, “fr-fr”, “fr-ca”).",
+                    "example": "en-us"
+                },
+                "permanentVehicleId": {
+                    "type": "integer",
+                    "description": "ID of the vehicle that has been permanently assigned to this driver.",
+                    "example": "879"
+                },
                 "driver": {
                     "$ref": "#/definitions/ExternalDriverResponse"
                 }

--- a/swagger.json
+++ b/swagger.json
@@ -4014,33 +4014,27 @@
                     "type": "string",
                     "description": "Reason that this driver is exempt from the Electronic Logging Mandate (see eldExempt)."
                 },
-                "eldBigDayExemptionEnabled": {
+                "usBigDayExemptionEnabled": {
                     "type": "boolean",
-                    "description": "Flag indicating this driver may use Big Day excemptions in ELD logs."
+                    "description": "Flag indicating this driver may use Big Day exemptions in HOS logs."
                 },
-                "eldAdverseWeatherExemptionEnabled": {
+                "usAdverseDrivingExemptionEnabled": {
                     "type": "boolean",
-                    "description": "Flag indicating this driver may use Adverse Weather exemptions in ELD logs."
+                    "description": "Flag indicating this driver may use Adverse Driving exemptions in HOS logs."
                 },
                 "eldPcEnabled": {
                     "type": "boolean",
-                    "description": "Flag indicating this driver may select the Personal Conveyance duty status in ELD logs.",
+                    "description": "Flag indicating this driver may select the Personal Conveyance duty status in HOS logs.",
                     "default": false
                 },
                 "eldYmEnabled": {
                     "type": "boolean",
-                    "description": "Flag indicating this driver may select the Yard Move duty status in ELD logs.",
+                    "description": "Flag indicating this driver may select the Yard Move duty status in HOS logs.",
                     "default": false
                 },
-                "eldDayStartHour": {
+                "hosDayStartHour": {
                     "type": "integer",
-                    "description": "0 indicating midnight-to-midnight ELD driving hours, 12 to indicate noon-to-noon driving hours."
-                },
-                "vehicleId": {
-                    "type": "integer",
-                    "format": "int64",
-                    "description":  "ID of the vehicle assigned to the driver for static vehicle assignments. (uncommon).",
-                    "example": 444
+                    "description": "0 indicating midnight-to-midnight HOS driving hours, 12 to indicate noon-to-noon driving hours."
                 },
                 "groupId": {
                     "type": "integer",


### PR DESCRIPTION
Live demo for these changes: https://rebilly.github.io/ReDoc/?url=https://raw.githubusercontent.com/samsarahq/api-docs/albert/arcbest-fleet-driver-updates/swagger.json

These doc updates are meant to reflect the changes specified in this [product spec](https://docs.google.com/document/d/1b9WG8e37rcG2P479nVNJx1D69evjSJRG-Pk9i54KnHA/edit#).

More context here and up-to-date specs for field descriptions here in the [engineering implementation spec](https://paper.dropbox.com/doc/Implementation-Spec-Driver-Settings-API-updates--ATHutWfTJT7~qla1JI2Qq77lAg-b0Y32QZTY8zTB8dCKk3hp#:h2=Use-the-new-graphql-endpoint-w).

Overall, the main change is that we want to expose more fields on the `/fleet/driver` endpoints for creating, reading, and updating driver objects.

There are three big changes:
1) return/accept more driver fields for POST /fleet/drivers/create, PATCH /fleet/drivers/:id, and all GETs
2) for POST /fleet/drivers -> return all driver info for each driver, not just id, name, and external id
3) deprecate old fields such as "eldBigDayExemptionEnabled" by removing them from the documentation here