### PR TITLE
Specify application/merge-patch+json content type for PATCH /fleet/drivers/:id

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -823,7 +823,7 @@
                 "description": "Update driver by id.",
                 "operationId": "patchDriverById",
                 "consumes": [
-                    "application/json"
+                    "application/merge-patch+json"
                 ],
                 "produces": [
                     "application/json"

--- a/swagger.json
+++ b/swagger.json
@@ -763,18 +763,18 @@
         },
         "/fleet/drivers/{driver_id | external_id}": {
             "get": {
-              "parameters": [
-                {
-                    "$ref": "#/parameters/accessTokenParam"
-                },
-                {
-                    "name": "driver_id | external_id",
-                    "in": "path",
-                    "required": true,
-                    "description": "Either the ID of the driver (integer) or corresponding external ID (alphanumeric string). One of these two parameters must be specified to identify the driver.",
-                    "type": "string"
-                }
-            ],
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/accessTokenParam"
+                    },
+                    {
+                        "name": "driver_id | external_id",
+                        "in": "path",
+                        "required": true,
+                        "description": "Either the ID of the driver (integer) or corresponding external ID (alphanumeric string). One of these two parameters must be specified to identify the driver.",
+                        "type": "string"
+                    }
+                ],
                 "tags": [
                     "Default", "Fleet", "Drivers"
                 ],
@@ -803,19 +803,19 @@
                 }
             },
             "patch": {
-              "parameters": [
-                {
-                    "$ref": "#/parameters/accessTokenParam"
-                },
-                {
-                    "name": "driver_id | external_id",
-                    "in": "path",
-                    "required": true,
-                    "description": "Either the ID of the driver (integer) or corresponding external ID (alphanumeric string). One of these two parameters must be specified to identify the driver.",
-                    "type": "string"
-                },
-                { "$ref": "#/parameters/driverParam" }
-            ],
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/accessTokenParam"
+                    },
+                    {
+                        "name": "driver_id | external_id",
+                        "in": "path",
+                        "required": true,
+                        "description": "Either the ID of the driver (integer) or corresponding external ID (alphanumeric string). One of these two parameters must be specified to identify the driver.",
+                        "type": "string"
+                    },
+                    { "$ref": "#/parameters/driverParam" }
+                ],
                 "tags": [
                     "Default", "Fleet", "Drivers"
                 ],
@@ -844,18 +844,18 @@
                 }
             },
             "delete": {
-              "parameters": [
-                {
-                    "$ref": "#/parameters/accessTokenParam"
-                },
-                {
-                    "name": "driver_id | external_id",
-                    "in": "path",
-                    "required": true,
-                    "description": "Either the ID of the driver (integer) or corresponding external ID (alphanumeric string). One of these two parameters must be specified to identify the driver.",
-                    "type": "string"
-                }
-            ],
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/accessTokenParam"
+                    },
+                    {
+                        "name": "driver_id | external_id",
+                        "in": "path",
+                        "required": true,
+                        "description": "Either the ID of the driver (integer) or corresponding external ID (alphanumeric string). One of these two parameters must be specified to identify the driver.",
+                        "type": "string"
+                    }
+                ],
                 "tags": [
                     "Default", "Fleet", "Drivers"
                 ],


### PR DESCRIPTION
Live Demo: https://rebilly.github.io/ReDoc/?url=https://raw.githubusercontent.com/samsarahq/api-docs/0aa26e4d53c4e51569f04039f3f650e45fa506c3/swagger.json#operation/patchDriverById

1) fix some indentation
2) specify `application/merge-patch+json` content type for PATCH /fleet/drivers/:id