### PR TITLE
swagger.json: Fix JSON validation errors

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -4589,7 +4589,7 @@
         "DispatchJobCreate": {
             "type": "object",
             "required": [
-                "scheduled_arrival_time_ms",
+                "scheduled_arrival_time_ms"
             ],
             "properties": {
                 "scheduled_arrival_time_ms": {
@@ -4627,13 +4627,13 @@
                 },
                 "destination_lat": {
                     "type": "number",
-                    "format": "float",
+                    "format": "double",
                     "description": "Latitude of the destination in decimal degrees. Optional if a valid destination address ID or destination address is provided.",
                     "example": 123.456
                 },
                 "destination_lng": {
                     "type": "number",
-                    "format": "float",
+                    "format": "double",
                     "description": "Longitude of the destination in decimal degrees. Optional if a valid destination address ID or destination address is provided.",
                     "example": 37.459
                 }


### PR DESCRIPTION
Removing the trailing comma from DispatchJobCreate required dictionary,
since trailing commas are not allowed in JSON.