### PR TITLE
api-docs: Fix address/lat/lng validation

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -4616,7 +4616,7 @@
                 },
                 "destination_address": {
                     "type": "string",
-                    "description": "The address of the job destination, as it would be recognized if provided to maps.google.com. Optional if a valid destination address ID or destination latitude/longitude pair is provided.",
+                    "description": "The address of the job destination, as it would be recognized if provided to maps.google.com. Optional if a valid destination address ID is provided.",
                     "example": "123 Main St, Philadelphia, PA 19106"
                 },
                 "destination_address_id": {
@@ -4628,13 +4628,13 @@
                 "destination_lat": {
                     "type": "number",
                     "format": "double",
-                    "description": "Latitude of the destination in decimal degrees. Optional if a valid destination address ID or destination address is provided.",
+                    "description": "Latitude of the destination in decimal degrees. Optional if a valid destination address ID is provided.",
                     "example": 123.456
                 },
                 "destination_lng": {
                     "type": "number",
                     "format": "double",
-                    "description": "Longitude of the destination in decimal degrees. Optional if a valid destination address ID or destination address is provided.",
+                    "description": "Longitude of the destination in decimal degrees. Optional if a valid destination address ID is provided.",
                     "example": 37.459
                 }
             }
@@ -4812,7 +4812,7 @@
                 },
                 "start_location_address": {
                     "type": "string",
-                    "description": "The address of the route's starting location, as it would be recognized if provided to maps.google.com. Optional if a valid start location address ID or start location latitude/longitude pair is provided.",
+                    "description": "The address of the route's starting location, as it would be recognized if provided to maps.google.com. Optional if a valid start location address ID is provided.",
                     "example": "123 Main St, Philadelphia, PA 19106"
                 },
                 "start_location_address_id": {
@@ -4824,13 +4824,13 @@
                 "start_location_lat": {
                     "type": "number",
                     "format": "double",
-                    "description": "Latitude of the start location in decimal degrees. Optional if a valid start location address ID or start location address is provided.",
+                    "description": "Latitude of the start location in decimal degrees. Optional if a valid start location address ID is provided.",
                     "example": 123.456
                 },
                 "start_location_lng": {
                     "type": "number",
                     "format": "double",
-                    "description": "Longitude of the start location in decimal degrees. Optional if a valid start location address ID or start location address is provided.",
+                    "description": "Longitude of the start location in decimal degrees. Optional if a valid start location address ID is provided.",
                     "example": 37.459
                 }
             }


### PR DESCRIPTION
Previously we were allowing users to omit {start-location|destination}
address if a valid lat/lng pair were provided (and vice versa).

Since we're not implementing geocoding/reverse geocoding in the near
future, these cases will be considered invalid for the time being.

This commit updates the API docs to reflect the stricter validation.