### PR TITLE
Fix message body for PATCH /fleet/drivers/id

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -4113,6 +4113,28 @@
                 }
             ]
         },
+        "DriverForUpdate": {
+            "allOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "isDeactivated": {
+                            "type": "boolean",
+                            "description": "True if the driver account has been deactivated."
+                        },
+                        "currentVehicleId": {
+                            "type": "integer",
+                            "format": "int64",
+                            "description": "ID of the vehicle that this driver is currently assigned to. Omitted if there is no current vehicle assignment for this driver.",
+                            "example": 879
+                        }
+                    }
+                },
+                {
+                    "$ref": "#/definitions/DriverBase"
+                }
+            ]
+        },
         "Driver": {
             "allOf": [
                 {
@@ -6771,7 +6793,7 @@
           "required": true,
           "in": "body",
           "schema": {
-            "$ref": "#/definitions/Driver"
+            "$ref": "#/definitions/DriverForUpdate"
           }
         },  
         "createDvirParam": {

--- a/swagger.json
+++ b/swagger.json
@@ -1223,7 +1223,7 @@
                         "description": "End of the time range, specified in milliseconds UNIX time.",
                         "type": "integer",
                         "format": "int64"
-                    },
+                    }
                 ],
                 "responses": {
                     "200": {
@@ -1276,7 +1276,7 @@
                         "description": "ID of the unassigned driving segment.",
                         "type": "string",
                         "format": "string"
-                    },
+                    }
                 ],
                 "responses": {
                     "200": {
@@ -3639,22 +3639,22 @@
                 "id": {
                     "type": "string",
                     "format": "string",
-                    "example": "MTU0MjE1NzkzNDAwMA",
+                    "example": "MTU0MjE1NzkzNDAwMA"
                 },
                 "vehicle_id": {
                     "type": "integer",
                     "format": "int64",
-                    "example": 212014918086169,
+                    "example": 212014918086169
                 },
                 "start_ms": {
                     "type": "integer",
                     "format": "int64",
-                    "example": 1523059200000,
+                    "example": 1523059200000
                 },
                 "end_ms": {
                     "type": "integer",
                     "format": "int64",
-                    "example": 1523059200000,
+                    "example": 1523059200000
                 },
                 "annotation": {
                     "type": "string",
@@ -3664,13 +3664,13 @@
                 "pending_driver_id": {
                     "type": "integer",
                     "format": "int64",
-                    "example": 719,
+                    "example": 719
                 },
                 "created_at_ms": {
                     "type": "integer",
                     "format": "int64",
-                    "example": 1523059200000,
-                },
+                    "example": 1523059200000
+                }
             }
         },
         "TemperatureResponse": {

--- a/swagger.json
+++ b/swagger.json
@@ -3963,9 +3963,6 @@
         },
         "DriverBase": {
             "type": "object",
-            "required": [
-                "name"
-            ],
             "properties": {
                 "name": {
                     "type": "string",
@@ -4100,6 +4097,9 @@
             "allOf": [
                 {
                     "type": "object",
+                    "required": [
+                        "name"
+                    ],
                     "properties": {
                         "password": {
                             "type": "string",
@@ -4140,7 +4140,8 @@
                 {
                     "type": "object",
                     "required": [
-                        "id"
+                        "id",
+                        "name"
                     ],
                     "properties": {
                         "id": {

--- a/swagger.json
+++ b/swagger.json
@@ -800,7 +800,7 @@
                         "description": "Either the ID of the driver (integer) or corresponding external ID (alphanumeric string). One of these two parameters must be specified to identify the driver.",
                         "type": "string"
                     },
-                    { "$ref": "#/parameters/driverParam" }
+                    { "$ref": "#/parameters/updateDriverParam" }
                 ],
                 "tags": [
                     "Default", "Fleet", "Drivers"
@@ -6765,7 +6765,7 @@
                 "$ref": "#/definitions/DriverForCreate"
             }
         },
-        "driverParam" : {
+        "updateDriverParam" : {
           "name": "driverParam",
           "description": "Driver update body",
           "required": true,


### PR DESCRIPTION
current docs: http://samsara-arcbest-api-preview-docs.s3-website-us-west-2.amazonaws.com/#operation/patchDriverById

live demo with changes: https://rebilly.github.io/ReDoc/?url=https://raw.githubusercontent.com/samsarahq/api-docs/5b8a5736e5a2716f928420e464efbf72adb79844/swagger.json#operation/patchDriverById

We're currently requiring `id` and `name` in the message body for PATCH /fleet/drivers/id. This PR creates a new `DriverForUpdate` object in swagger that

1) removes `id` from the message body, since we're passing it in as a url param, and
2) changes the `name` field from required -> normal

The last commit to remove trailing commas is just for cleanup.