### PR TITLE
Advith/arcbest_external_id_modifications

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -757,7 +757,7 @@
                         "name": "driver_id | external_id",
                         "in": "path",
                         "required": true,
-                        "description": "Either the ID of the driver (integer) or corresponding external ID (alphanumeric string). One of these two parameters must be specified to identify the driver.",
+                        "description": "Either the ID of the driver (integer) or corresponding external ID key:value pair (ex. payroll:1). One of these two parameters must be specified to identify the driver.",
                         "type": "string"
                     }
                 ],
@@ -797,7 +797,7 @@
                         "name": "driver_id | external_id",
                         "in": "path",
                         "required": true,
-                        "description": "Either the ID of the driver (integer) or corresponding external ID (alphanumeric string). One of these two parameters must be specified to identify the driver.",
+                        "description": "Either the ID of the driver (integer) or corresponding external ID key:value pair (ex. payroll:1). One of these two parameters must be specified to identify the driver.",
                         "type": "string"
                     },
                     { "$ref": "#/parameters/updateDriverParam" }
@@ -838,7 +838,7 @@
                         "name": "driver_id | external_id",
                         "in": "path",
                         "required": true,
-                        "description": "Either the ID of the driver (integer) or corresponding external ID (alphanumeric string). One of these two parameters must be specified to identify the driver.",
+                        "description": "Either the ID of the driver (integer) or corresponding external ID key:value pair (ex. payroll:1). One of these two parameters must be specified to identify the driver.",
                         "type": "string"
                     }
                 ],
@@ -913,7 +913,7 @@
                     "name": "driver_id | external_id",
                     "in": "path",
                     "required": true,
-                    "description": "ID (integer) of the deactivated driver or corresponding external ID (alphanumeric string).",
+                    "description": "ID (integer) of the deactivated driver or corresponding external ID key:value pair (ex. payroll:1).",
                     "type": "string"
                 }
             ],
@@ -1047,12 +1047,12 @@
             }
           }
         },
-        "/fleet/drivers/{driver_id | external_id}/hos_daily_logs": {
+        "/fleet/drivers/{driver_id}/hos_daily_logs": {
           "post": {
             "tags": [
               "Fleet", "Default"
             ],
-            "summary": "/fleet/drivers/{driver_id:[0-9]+ | external_id:[a-zA-Z0-9]+}/hos_daily_logs",
+            "summary": "/fleet/drivers/{driver_id:[0-9]+}/hos_daily_logs",
             "description": "Get summarized daily HOS charts for a specified driver.",
             "operationId": "get_fleet_drivers_hos_daily_logs",
             "parameters": [
@@ -1060,10 +1060,10 @@
                     "$ref": "#/parameters/accessTokenParam"
                 },
                 {
-                    "name": "driver_id | external_id",
+                    "name": "driver_id",
                     "in": "path",
                     "required": true,
-                    "description": "ID (integer) of the driver with HOS logs or corresponding external ID (alphanumeric string).",
+                    "description": "ID (integer) of the driver with HOS logs.",
                     "type": "string"
                 },
                 {
@@ -1960,16 +1960,16 @@
                 }
             }
         },
-        "/fleet/drivers/{driver_id | external_id}/dispatch/routes": {
+        "/fleet/drivers/{driver_id}/dispatch/routes": {
             "parameters": [
                 {
                     "$ref": "#/parameters/accessTokenParam"
                 },
                 {
-                    "name": "driver_id | external_id",
+                    "name": "driver_id",
                     "in": "path",
                     "required": true,
-                    "description": "ID (integer) of the driver with the associated routes or corresponding external ID (alphanumeric string).",
+                    "description": "ID (integer) of the driver with the associated routes.",
                     "type": "string"
                 }
             ],
@@ -1979,7 +1979,7 @@
                     "Fleet",
                     "Routes"
                 ],
-                "summary": "/fleet/drivers/{driver_id:[0-9]+ | external_id:[a-zA-Z0-9]+}/dispatch/routes",
+                "summary": "/fleet/drivers/{driver_id:[0-9]+}/dispatch/routes",
                 "description": "Fetch all of the dispatch routes for a given driver.",
                 "operationId": "getDispatchRoutesByDriverId",
                 "consumes": [
@@ -2011,7 +2011,7 @@
                 "tags": [
                     "Default", "Fleet", "Routes"
                 ],
-                "summary": "/fleet/drivers/{driver_id:[0-9]+ | external_id:[a-zA-Z0-9]+}/dispatch/routes",
+                "summary": "/fleet/drivers/{driver_id:[0-9]+}/dispatch/routes",
                 "description": "Create a new dispatch route for the driver with driver_id.",
                 "operationId": "createDriverDispatchRoute",
                 "consumes": [
@@ -2048,17 +2048,46 @@
               "name": "vehicle_id | external_id",
               "in": "path",
               "required": true,
-              "description": "ID (integer) of the vehicle or corresponding external ID (alphanumeric string).",
+              "description": "ID (integer) of the vehicle or corresponding external ID key:value pair (ex. payroll:1).",
               "type": "string"
             }
           ],
+          "get": {
+              "tags": [
+                  "Default",
+                  "Fleet"
+              ],
+              "summary": "/fleet/vehicles/{vehicle_id | external_id}",
+              "description": "Get a vehicle given either a vehicle ID or external ID key:value pair (ex. payroll:1).",
+              "operationId": "getVehicle",
+              "consumes": [
+                  "application/json"
+              ],
+              "produces": [
+                  "application/json"
+              ],
+              "responses": {
+                  "200": {
+                      "description": "Returns vehicle.",
+                      "schema": {
+                          "$ref": "#/definitions/VehicleResponse"
+                      }
+                  },
+                  "default": {
+                    "description": "Unexpected error.",
+                    "schema": {
+                      "$ref": "#/definitions/ErrorResponse"
+                    }     
+                  }
+              }
+          },
           "patch": {
             "tags": [
               "Default",
               "Fleet"
             ],
             "summary": "/fleet/vehicles/{vehicle_id | external_id}",
-            "description": "Updates a vehicle given either a vehicle ID or external ID (alphanumeric string)",
+            "description": "Updates a vehicle given either a vehicle ID or external ID key:value pair (ex. payroll:1)",
             "operationId": "updateVehicle",
             "consumes": [
               "application/json"
@@ -2068,7 +2097,10 @@
             ],
             "responses": {
               "200": {
-                "description": "Returns updated vehicle."
+                "description": "Returns updated vehicle.",
+                "schema": {
+                    "$ref": "#/definitions/VehicleResponse"
+                }
               },
               "default": {
                 "description": "Unexpected error.",
@@ -2129,16 +2161,16 @@
             }
           }
         },
-        "/fleet/vehicles/{vehicle_id | external_id}/dispatch/routes": {
+        "/fleet/vehicles/{vehicle_id}/dispatch/routes": {
             "parameters": [
                 {
                     "$ref": "#/parameters/accessTokenParam"
                 },
                 {
-                    "name": "vehicle_id | external_id",
+                    "name": "vehicle_id",
                     "in": "path",
                     "required": true,
-                    "description": "ID (integer) of the vehicle with the associated routes or corresponding external ID (alphanumeric string).",
+                    "description": "ID (integer) of the vehicle with the associated routes.",
                     "type": "string"
                 }
             ],
@@ -2148,7 +2180,7 @@
                     "Fleet",
                     "Routes"
                 ],
-                "summary": "/fleet/vehicles/{vehicle_id:[0-9]+ | external_id:[a-zA-Z0-9]+}/dispatch/routes",
+                "summary": "/fleet/vehicles/{vehicle_id:[0-9]+}/dispatch/routes",
                 "description": "Fetch all of the dispatch routes for a given vehicle.",
                 "operationId": "getDispatchRoutesByVehicleId",
                 "consumes": [
@@ -2163,7 +2195,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Returns all of the dispatch routes for the given vehicle_id or external_id.",
+                        "description": "Returns all of the dispatch routes for the given vehicle_id.",
                         "schema": {
                             "$ref": "#/definitions/DispatchRoutes"
                         }
@@ -2180,8 +2212,8 @@
                 "tags": [
                     "Default", "Fleet", "Routes"
                 ],
-                "summary": "/fleet/vehicles/{vehicle_id:[0-9]+ | external_id:[a-zA-Z0-9]+}/dispatch/routes",
-                "description": "Create a new dispatch route for the vehicle with vehicle_id or external_id.",
+                "summary": "/fleet/vehicles/{vehicle_id:[0-9]+}/dispatch/routes",
+                "description": "Create a new dispatch route for the vehicle with vehicle_id.",
                 "operationId": "createVehicleDispatchRoute",
                 "consumes": [
                     "application/json"
@@ -2208,16 +2240,16 @@
                 }
             }
         },
-        "/fleet/vehicles/{vehicle_id | external_id}/locations": {
+        "/fleet/vehicles/{vehicle_id}/locations": {
           "parameters": [
             {
               "$ref": "#/parameters/accessTokenParam"
             },
             {
-              "name": "vehicle_id | external_id",
+              "name": "vehicle_id",
               "in": "path",
               "required": true,
-              "description": "ID (integer) of the vehicle with the associated routes or corresponding external ID (alphanumeric string).",
+              "description": "ID (integer) of the vehicle with the associated routes.",
               "type": "string"
             },
             {
@@ -2242,7 +2274,7 @@
               "Default",
               "Fleet"
             ],
-            "summary": "/fleet/vehicles/{vehicle_id:[0-9]+ | external_id:[a-zA-Z0-9]+}/locations",
+            "summary": "/fleet/vehicles/{vehicle_id:[0-9]+}/locations",
             "description": "Fetch locations for a given vehicle between a start/end time. The maximum query duration is one hour.",
             "operationId": "getVehicleLocations",
             "consumes": [
@@ -2338,16 +2370,16 @@
                 }
             }
         },
-        "/fleet/drivers/{driver_id | external_id}/documents": {
+        "/fleet/drivers/{driver_id}/documents": {
             "parameters": [
                 {
                     "$ref": "#/parameters/accessTokenParam"
                 },
                 {
-                    "name": "driver_id | external_id",
+                    "name": "driver_id",
                     "in": "path",
                     "required": true,
-                    "description": "ID (integer) of the driver for whom the document is created or corresponding external ID (alphanumeric string).",
+                    "description": "ID (integer) of the driver for whom the document is created.",
                     "type": "string"
                 }
             ],
@@ -2356,7 +2388,7 @@
                     "Default",
                     "Fleet"
                 ],
-                "summary": "/fleet/drivers/{driver_id:[0-9]+ | external_id:[a-zA-Z0-9]+}/documents",
+                "summary": "/fleet/drivers/{driver_id:[0-9]+}/documents",
                 "description": "Create a driver document for the given driver.",
                 "operationId": "createDriverDocument",
                 "consumes": [
@@ -3818,45 +3850,6 @@
                 }
             }
         },
-        "ExternalDriverResponse" : {
-            "type": "object",
-            "description": "Driver object",
-            "properties": {
-                "driverId": {
-                    "type": "integer",
-                    "description": "ID of the driver.",
-                    "example": 719
-                },
-                "externalIds" : {
-                    "type": "object",
-                    "description": "Dictionary of external IDs (string key-value pairs)",
-                    "additionalProperties": {
-                      "type": "string"
-                    },
-                    "example": {"payrollId": "123", "internalDriverId": "250020"}
-                  }
-            }
-        },
-        "ExternalVehicleResponse": {
-            "type": "object",
-            "description": "Vehicle object",
-            "properties": {
-                "vehicle_id": {
-                    "type": "integer",
-                    "format": "int64",
-                    "description": "ID of the vehicle used for the dispatch job.",
-                    "example": 112
-                },
-                "externalIds" : {
-                  "type": "object",
-                  "description": "Dictionary of external IDs (string key-value pairs)",
-                  "additionalProperties": {
-                    "type": "string"
-                  },
-                  "example": {"internalVehicleId": "ABFS18600"}
-                }
-            }
-        },
         "TripResponse": {
             "type": "object",
             "description": "Contains the trips for the vehicle in the requested timeframe. A trip is represented as an object that contains startMs, startLocation, startAddress, startCoordinates, endMs, endLocation, endAddress and endCoordinates.",
@@ -3942,9 +3935,6 @@
                                 "type": "integer",
                                 "description": "Length in meters trip spent on toll roads.",
                                 "example": 32000
-                            },
-                            "driver": {
-                                "$ref": "#/definitions/ExternalDriverResponse"
                             },
                             "startOdometer": {
                                 "type": "integer",
@@ -4088,9 +4078,14 @@
                     "description": "ID of the vehicle that has been permanently assigned to this driver.",
                     "example": "879"
                 },
-                "driver": {
-                    "$ref": "#/definitions/ExternalDriverResponse"
-                }
+                "externalIds" : {
+                    "type": "object",
+                    "description": "Dictionary of external IDs (string key-value pairs)",
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "example": {"payrollId": "123", "maintenanceId": "250020"}
+                  }
             }
         },
         "DriverForCreate": {
@@ -4209,7 +4204,7 @@
                                     "additionalProperties": {
                                         "type": "string"
                                     },
-                                    "example": {"payrollId": "123", "internalDriverId": "250020"}
+                                    "example": {"payrollId": "123", "maintenanceId": "250020"}
                                     }
                                 }
                             }
@@ -4636,9 +4631,6 @@
                     "type": "string",
                     "description": "Inspection type of the DVIR.",
                     "example": "pre trip"
-                  },
-                  "vehicle": {
-                    "$ref": "#/definitions/ExternalVehicleResponse"
                   },
                   "vehicleDefects": {
                     "type": "array",
@@ -5316,12 +5308,6 @@
                             "description": "ID of the route that this job belongs to.",
                             "example": 55
                         },
-                        "driver": {
-                          "$ref": "#/definitions/ExternalDriverResponse"
-                        },
-                        "vehicle": {
-                          "$ref": "#/definitions/ExternalVehicleResponse"
-                        },
                         "fleet_viewer_url": {
                             "type": "string",
                             "description": "Fleet viewer url of the dispatch job.",
@@ -5383,12 +5369,6 @@
                 "start_location_lng"
             ],
             "properties": {
-                "vehicle": {
-                  "$ref": "#/definitions/ExternalVehicleResponse"
-                },
-                "driver": {
-                  "$ref": "#/definitions/ExternalDriverResponse"
-                },
                 "actual_start_ms": {
                     "type": "integer",
                     "format": "int64",
@@ -5640,6 +5620,62 @@
                     "description": "Notes about the machine",
                     "example": "This is in the left hallway behind the conveyor belt"
                 }
+            }
+        },
+        "VehicleResponse": {
+            "type": "object",
+            "description": "Contains information about the vehicle",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "description": "ID of the vehicle.",
+                    "format": "int64",
+                    "example": 123
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the vehicle",
+                    "format": "string",
+                    "example": "Bob's Truck"
+                },
+                "make": {
+                    "type": "string",
+                    "description": "Make of the vehicle",
+                    "format": "string",
+                    "example": "Toyota"
+                },
+                "model": {
+                    "type": "string",
+                    "description": "Model of the vehicle",
+                    "format": "string",
+                    "example": "Corolla"
+                },              
+                "vin": {
+                    "type": "string",
+                    "description": "VIN of the vehicle",
+                    "format": "string",
+                    "example": "1HGBH41JXMN109186"
+                },
+                "year": {
+                    "type": "integer",
+                    "description": "Year the vehicle was made.",
+                    "format": "int64",
+                    "example": "2017"
+                },     
+                "harshAccelSetting": {
+                    "type": "integer",
+                    "description": "A number from 1-10 indicating the harsh acceleration setting of the vehicle",
+                    "format": "int64",
+                    "example": "2017"
+                },                            
+                "externalIds" : {
+                    "type": "object",
+                    "description": "Dictionary of external IDs (string key-value pairs)",
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "example": {"maintenanceId": "ABFS18600"}
+                  }
             }
         },
         "MachineHistoryResponse": {


### PR DESCRIPTION
Add documentation to reflect only the following external ID changes:

New endpoints:
`GET, PATCH /fleet/vehicles/{vehicle_id or external_id}`

Changed request, response in endpoints:
`GET /fleet/drivers/`
`POST /fleet/drivers/create`
`GET, DELETE, PATCH /fleet/drivers/{driver_id or external_id}`
`GET /fleet/drivers/inactive/`
`GET, PUT /fleet/drivers/inactive/{driver_id or external_id}`