### PR TITLE
add addresses to tag GET endpoints

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -4362,6 +4362,37 @@
                 }
             ]
         },
+        "TaggedAddressBase": {
+            "type": "object",
+            "required": [
+                "id"
+            ],
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64",
+                    "description": "The ID of the address being tagged.",
+                    "example": 345
+                }
+            }
+        },
+        "TaggedAddress": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/TaggedAddressBase"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the address being tagged.",
+                            "example": "Truck Lot 345"
+                        }
+                    }
+                }
+            ]
+        },
         "TagCreate": {
             "type": "object",
             "required": [
@@ -4629,6 +4660,13 @@
                             "$ref": "#/definitions/TaggedSensor"
                         },
                         "description": "The sensors that belong to this tag."
+                    },
+                    "addresses": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/TaggedAddress"
+                        },
+                        "description": "The addresses that belong to this tag."
                     }
                 }
         },


### PR DESCRIPTION
Add address object to tag single GET and tag LIST responses. 

View docs here: https://rebilly.github.io/ReDoc/?url=https://raw.githubusercontent.com/samsarahq/api-docs/d1bf43ea37a13a68ae8f607ddf6895bdec41762b/swagger.json#operation/GetOrganizationContact