### PR TITLE
Correct information for /hos_daily_logs response

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -3685,7 +3685,7 @@
         "DriverDailyLogResponse": {
           "type": "object",
           "properties": {
-            "summaries": {
+            "days": {
               "type": "array",
               "items": {
                 "type": "object",


### PR DESCRIPTION
[API-190] documentation is incorrect - for /fleet/drivers/{id}/hos_daily_logs response, the key is "days", not "summaries"