### PR TITLE
dvir GET & POST: add userEmail to POST and correct examples for GET

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -4385,17 +4385,17 @@
                         "name": {
                             "type": "string",
                             "description": "The name of the driver or mechanic who signed the DVIR.",
-                            "example": "driver"
+                            "example": "John Smith"
                         },
                         "username": {
                             "type": "string",
                             "description": "Username of the  driver|mechanic who signed the DVIR.",
-                            "example": "driver"
+                            "example": "jsmith"
                         },
                         "email": {
                             "type": "string",
                             "description": "Email of the  driver|mechanic who signed the DVIR.",
-                            "example": "driver"
+                            "example": "j.smith@yahoo.com"
                         },
                         "signedAt": {
                             "type": "integer",
@@ -4417,17 +4417,17 @@
                         "name": {
                             "type": "string",
                             "description": "The name of the agent or mechanic who signed the DVIR.",
-                            "example": "driver"
+                            "example": "John Smith"
                         },
                         "username": {
                             "type": "string",
                             "description": "Username of the  agent|mechanic who signed the DVIR.",
-                            "example": "driver"
+                            "example": "jsmith"
                         },
                         "email": {
                             "type": "string",
                             "description": "Email of the  agent|mechanic who signed the DVIR.",
-                            "example": "driver"
+                            "example": "j.smith@yahoo.com"
                         },
                         "signedAt": {
                             "type": "integer",
@@ -4449,17 +4449,17 @@
                         "name": {
                             "type": "string",
                             "description": "The name of the driver who signed the next DVIR on this vehicle.",
-                            "example": "driver"
+                            "example": "John Smith"
                         },
                         "username": {
                             "type": "string",
                             "description": "Username of the  driver who signed the next DVIR on this vehicle.",
-                            "example": "driver"
+                            "example": "jsmith"
                         },
                         "email": {
                             "type": "string",
                             "description": "Email of the  driver who signed the next DVIR on this vehicle.",
-                            "example": "driver"
+                            "example": "j.smith@yahoo.com"
                         },
                         "signedAt": {
                             "type": "integer",
@@ -6469,7 +6469,8 @@
                 "type": "object",
                 "required": [
                     "safe",
-                    "inspectionType"
+                    "inspectionType",
+                    "userEmail"
                 ],
                 "properties": {
                     "safe" : {
@@ -6518,6 +6519,11 @@
                         "type": "string",
                         "description": "Any notes from the mechanic.",
                         "example": "Replaced headlight on passenger side."
+                    }, 
+                    "userEmail": {
+                        "type": "string",
+                        "description": "The Samsara login email for the person creating the DVIR. The email must correspond to a Samsara user's email.",
+                        "example": "j.smith@yahoo.com"
                     }
                 }
             }


### PR DESCRIPTION
GET for dvirs:
- corrected example data for signature fields

POST for mechanic-style dvirs:
- add required userEmail field

Preview:
https://rebilly.github.io/ReDoc/?url=https://raw.githubusercontent.com/samsarahq/api-docs/f760253af02565d9afe574a626924e0542cfb4b8/swagger.json