### PR TITLE
swagger.json: Fix ErrorResponse to be simple string

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -4220,19 +4220,8 @@
             }
         },
         "ErrorResponse": {
-            "type": "object",
-            "description": "Contains the error response when a request fails.",
-            "properties": {
-                "status_code": {
-                    "type": "integer",
-                    "description": "HTTP status code returned.",
-                    "format": "int64"
-                },
-                "message": {
-                    "type": "string",
-                    "description": "Error message returned."
-                }
-            }
+            "type": "string",
+            "description": "Error message describing why the request failed."
         },
         "SensorHistoryResponse": {
             "type": "object",


### PR DESCRIPTION
Our server currently returns a simple string error response, so updating this `ErrorResponse` to be a simple string. This unblocks our generated SDKs to handle errors correctly. 