### PR TITLE
swagger.json: update DriversResponse to use Driver objects

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -3869,20 +3869,7 @@
                 "drivers": {
                     "type": "array",
                     "items": {
-                        "type": "object",
-                        "properties": {
-                            "id": {
-                                "type": "integer",
-                                "format": "int64",
-                                "description": "ID of the driver.",
-                                "example": 444
-                            },
-                            "name": {
-                                "type": "string",
-                                "description": "Name of the driver.",
-                                "example": "Fred Jacobs"
-                            }
-                        }
+                        "$ref": "#/definitions/Driver"
                     }
                 }
             }


### PR DESCRIPTION
now that the active and inactive fleet driver list endpoints are returning the same response, the `DriversResponse` can be made to use the `Driver` object