### PR TITLE
Add driveMsToday, onDutyMsToday, pendingDriveMsToday, and pendingOnDutyToday Ms to hos_logs_summary

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -4584,6 +4584,30 @@
                     "format": "int64",
                     "description": "The amount of driving time in violation in this cycle (in ms).",
                     "example": 50400000
+                  },
+                  "onDutyMsToday": {
+                    "type": "number",
+                    "format": "int64",
+                    "description": "The amount of on duty time today (in ms).",
+                    "example": 50400000
+                  },
+                  "driveMsToday": {
+                    "type": "number",
+                    "format": "int64",
+                    "description": "The amount of driving time today (in ms).",
+                    "example": 34200000
+                  },
+                  "pendingOnDutyMsToday": {
+                    "type": "number",
+                    "format": "int64",
+                    "description": "The amount of on duty time today for pending logs (in ms).",
+                    "example": 21600000
+                  },
+                  "pendingDriveMsToday": {
+                    "type": "number",
+                    "format": "int64",
+                    "description": "The amount of driving time today for pending logs (in ms).",
+                    "example": 21600000
                   }
                 }
               }


### PR DESCRIPTION
Adds `driveMsToday`, `onDutyMsToday`, `pendingDriveMsToday`, and `pendingOnDutyMsToday` to the `/fleet/hos_logs_summary` endpoint.