### PR TITLE
Update driver info api endpoints (/fleet/drivers/...)

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -4280,10 +4280,6 @@
                 {
                     "type": "object",
                     "properties": {
-                        "isDeactivated": {
-                            "type": "boolean",
-                            "description": "True if the driver account has been deactivated."
-                        },
                         "currentVehicleId": {
                             "type": "integer",
                             "format": "int64",

--- a/swagger.json
+++ b/swagger.json
@@ -4124,7 +4124,7 @@
                 "username": {
                     "type": "string",
                     "description": "Driver's login username into the driver app.",
-                    "example": "Susan Jones"
+                    "example": "susanjones"
                 },
                 "phone": {
                     "type": "string",
@@ -4143,24 +4143,28 @@
                 },
                 "eldExempt": {
                     "type": "boolean",
-                    "description": "Flag indicating this driver is exempt from the Electronic Logging Mandate."
+                    "description": "Flag indicating this driver is exempt from the Electronic Logging Mandate.",
+                    "example": false
                 },
                 "eldExemptReason": {
                     "type": "string",
-                    "description": "Reason that this driver is exempt from the Electronic Logging Mandate (see eldExempt)."
+                    "description": "Reason that this driver is exempt from the Electronic Logging Mandate (see eldExempt).",
+                    "example": "Some reason."
                 },
                 "usBigDayExemptionEnabled": {
                     "type": "boolean",
-                    "description": "Flag indicating this driver may use Big Day exemptions in HOS logs."
+                    "description": "Flag indicating this driver may use Big Day exemptions in HOS logs.",
+                    "example": true
                 },
                 "usAdverseDrivingExemptionEnabled": {
                     "type": "boolean",
-                    "description": "Flag indicating this driver may use Adverse Driving exemptions in HOS logs."
+                    "description": "Flag indicating this driver may use Adverse Driving exemptions in HOS logs.",
+                    "example": true
                 },
                 "eldPcEnabled": {
                     "type": "boolean",
                     "description": "Flag indicating this driver may select the Personal Conveyance duty status in HOS logs.",
-                    "default": false
+                    "default": false,
                 },
                 "eldYmEnabled": {
                     "type": "boolean",
@@ -4169,7 +4173,8 @@
                 },
                 "hosDayStartHour": {
                     "type": "integer",
-                    "description": "0 indicating midnight-to-midnight HOS driving hours, 12 to indicate noon-to-noon driving hours."
+                    "description": "0 indicating midnight-to-midnight HOS driving hours, 12 to indicate noon-to-noon driving hours.",
+                    "example": 12
                 },
                 "groupId": {
                     "type": "integer",
@@ -4195,7 +4200,6 @@
                 "carrierUsDotNumberOverride": {
                     "type": "integer",
                     "description": "Carrier’s US DOT number (max: 999999999), if different from the organization default.",
-                    "example": "999999999"
                 },
                 "tags": {
                     "type": "array",
@@ -4204,6 +4208,7 @@
                         "type": "string",
                         "example": "R05_004"
                     }
+                    "example": 999999999
                 },
                 "notes": {
                     "type": "string",
@@ -4238,7 +4243,7 @@
                 "permanentVehicleId": {
                     "type": "integer",
                     "description": "ID of the vehicle that has been permanently assigned to this driver.",
-                    "example": "879"
+                    "example": 879
                 },
                 "externalIds" : {
                     "type": "object",

--- a/swagger.json
+++ b/swagger.json
@@ -4200,14 +4200,6 @@
                 "carrierUsDotNumberOverride": {
                     "type": "integer",
                     "description": "Carrier’s US DOT number (max: 999999999), if different from the organization default.",
-                },
-                "tags": {
-                    "type": "array",
-                    "description": "An array of tags that the driver belongs to.",
-                    "items": {
-                        "type": "string",
-                        "example": "R05_004"
-                    }
                     "example": 999999999
                 },
                 "notes": {
@@ -4267,6 +4259,9 @@
                             "type": "string",
                             "description": "Driver's password for the driver app.",
                             "example": "mypassword"
+                        },
+                        "tagIds": {
+                            "$ref": "#/definitions/TagIds"
                         }
                     }
                 },
@@ -4285,6 +4280,9 @@
                             "format": "int64",
                             "description": "ID of the vehicle that this driver is currently assigned to. Omitted if there is no current vehicle assignment for this driver.",
                             "example": 879
+                        },
+                        "tagIds": {
+                            "$ref": "#/definitions/TagIds"
                         }
                     }
                 },
@@ -4353,6 +4351,11 @@
                                         "type": "string"
                                     },
                                     "example": {"payrollId": "123", "maintenanceId": "250020"}
+                                    "tags": {
+                                        "type": "array",
+                                        "items": {
+                                            "$ref": "#/definitions/TagMetadata"
+                                        }
                                     }
                                 }
                             }

--- a/swagger.json
+++ b/swagger.json
@@ -4192,7 +4192,7 @@
                     "description": "Carrier’s name, if different from the organization default.",
                     "example": "Samsara"
                 },
-                "mainOfficeAddressOverride": {
+                "carrierAddressOverride": {
                     "type": "string",
                     "description": "Carrier’s office address, if different from the organization default.",
                     "example": "444 De Haro St, San Francisco"
@@ -4215,10 +4215,10 @@
                     "description": "Notes about the driver.",
                     "example": "Driver operates in the West."
                 },
-                "vehicleSelectionTags": {
-                    "type": "string",
-                    "description": "Tag containing vehicles a driver may select from in the Driver app.",
-                    "example": "West"
+                "vehicleGroupTagId": {
+                    "type": "integer",
+                    "description": "Tag Id containing vehicles a driver may select from in the Driver app. Omitted if there is no current tag id set. If deleting an existing tag id, use `null`.",
+                    "example": 22
                 },
                 "caOffDutyDeferralExemptionEnabled": {
                     "type": "boolean",

--- a/swagger.json
+++ b/swagger.json
@@ -963,10 +963,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Returns the reactivated driver, which is now available at /fleet/drivers/{driver_id}.",
-                        "schema": {
-                            "$ref": "#/definitions/CurrentDriver"
-                        }
+                        "description": "Successfully reactivated the driver, which is now referenced by /fleet/drivers/{driver_id | external_id}.",
                     },
                     "default": {
                         "description": "Unexpected error.",

--- a/swagger.json
+++ b/swagger.json
@@ -4345,12 +4345,13 @@
                                 "type": "object",
                                 "properties": {
                                     "externalIds" : {
-                                    "type": "object",
-                                    "description": "Dictionary of external IDs (string key-value pairs)",
-                                    "additionalProperties": {
-                                        "type": "string"
+                                        "type": "object",
+                                        "description": "Dictionary of external IDs (string key-value pairs)",
+                                        "additionalProperties": {
+                                            "type": "string"
+                                        },
+                                        "example": {"payrollId": "123", "maintenanceId": "250020"}
                                     },
-                                    "example": {"payrollId": "123", "maintenanceId": "250020"}
                                     "tags": {
                                         "type": "array",
                                         "items": {

--- a/swagger.json
+++ b/swagger.json
@@ -4173,7 +4173,7 @@
                 },
                 "hosDayStartHour": {
                     "type": "integer",
-                    "description": "0 indicating midnight-to-midnight HOS driving hours, 12 to indicate noon-to-noon driving hours.",
+                    "description": "0 indicates midnight-to-midnight HOS driving hours, 12 indicates noon-to-noon driving hours.",
                     "example": 12
                 },
                 "groupId": {


### PR DESCRIPTION
preview link: https://rebilly.github.io/ReDoc/?url=https://raw.githubusercontent.com/samsarahq/api-docs/1d4060fefcfdf0ae20def22621775f8206635080/swagger.json#operation/patchDriverById
jira: https://samsaradev.atlassian.net/browse/CM-423

- remove driver object in response for PUT /fleet/drivers/inactive/:id
- remove `isDeactivated` field from PATCH /fleet/drivers/:id (because we don't support modifying this field on PATCH)
- use `tagIds` in incoming requests (PATCH, POST), and return `tags` in responses (GET, PATCH, POST)
- match some driver fields to their gql variable names for consistency
- fix incorrect or missing examples 