### PR TITLE
swagger: Fix bug on POST fleet/drivers/:driver_id/documents

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -6185,17 +6185,6 @@
                 "$ref": "#/definitions/DocumentField"
             }
         },
-        "DocumentFieldCreates": {
-            "type": "array",
-            "example": [
-                {"valueType": "ValueType_Photo", "photoValue": []},
-                {"valueType": "ValueType_Number", "numberValue": 12.34 },
-                {"valueType": "ValueType_String", "stringValue": "San Francisco, CA" }
-            ],
-            "items": {
-                "$ref": "#/definitions/DocumentFieldCreate"
-            }
-        },
         "DocumentBase": {
             "type": "object",
             "properties": {
@@ -6277,8 +6266,13 @@
                             "description": "List of fields should match the document type’s list of field types in the correct order. In other words, a field's valueType and value (i.e. only one of: stringValue, numberValue, or photoValue) at index _i_ should match with the document field type’s valueType at index _i_.",
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/DocumentFieldCreates"
-                            }
+                                "$ref": "#/definitions/DocumentField"
+                            },
+                            "example": [
+                                {"valueType": "ValueType_Photo", "photoValue": []},
+                                {"valueType": "ValueType_Number", "numberValue": 12.34 },
+                                {"valueType": "ValueType_String", "stringValue": "San Francisco, CA" }
+                            ]
                         }
                     }
                 },


### PR DESCRIPTION
Previously, the documentation showed the `"fields"` parameter wrapped in 2 arrays:
<img width="471" alt="screen shot 2019-01-30 at 1 04 15 pm" src="https://user-images.githubusercontent.com/7097950/52012623-e9073e00-248f-11e9-8470-ab2a4c2292f2.png">

Now it should not be:
<img width="1552" alt="screen shot 2019-01-30 at 1 03 57 pm" src="https://user-images.githubusercontent.com/7097950/52012690-19e77300-2490-11e9-9a3d-759bae2d76a6.png">

This was brought up by Gordon when making documents.