### PR TITLE
swagger: remove the incorrect AUTO_DUTY enum from audit_logs

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -5255,7 +5255,6 @@
                         "OFF_DUTY", 
                         "SLEEPER_BED", 
                         "DRIVING",
-                        "AUTO_DUTY",
                         "ON_DUTY", 
                         "YARD_MOVE", 
                         "PERSONAL_CONVEYANCE"


### PR DESCRIPTION
All logs returned from the audit logs API include the corresponding log status for statusType regardless of whether they were created via auto duty or a manual driver status change.