### PR TITLE
add beta docs folder

### DIFF
--- a/beta/README.md
+++ b/beta/README.md
@@ -1,0 +1,2 @@
+This is documentation for the unstable/future APIs release.
+Breaking changes may be introduced.


### PR DESCRIPTION
Adds a placeholder for the beta docs so we can add the beta docs to the swagger deploy pipeline.

The intention is that `swagger.json` will always be what our default public docs are based off, so when we release the beta API endpoints then we will...

* move the existing `swagger.json` to `v1/swagger.json`
* move `beta/swagger.json` to `swagger.json`
* remove the `beta` folder.

I'm creating this placeholder PR first so we can agree on the structure of the beta swagger before we add it to the deploy pipeline.