### PR TITLE
add base swagger kondo file for marketing to have something to render

### DIFF
--- a/swagger-preview.json
+++ b/swagger-preview.json
@@ -1,0 +1,17 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Samsara API [PREVIEW]",
+    "version": "1.0.0",
+    "description": "Welcome to the Samsara API."
+  },
+  "host": "api.samsara.com",
+  "schemes": ["https"],
+  "consumes": ["application/json"],
+  "produces": ["application/json"],
+  "tags": [],
+  "paths": {},
+  "definitions": {},
+  "parameters": {}
+}
+


### PR DESCRIPTION
As we transition to kondo, the growth team is helping us setup a samsara.com/api-preview page that renders a swagger as an analog to the current samsara.com/api page. This is a initial base swagger for growth to use.

We likely do not want to have an automated pipeline setup that syncs backend kondo swagger with this one yet because we want to do staged launches as opposed to a continuous deployment of doc changes.

NOTE: we also need to clean up this description, but for now it is just acting as a dummy file to give growth something to render.