### PR TITLE
Add ANNOTATED as possible status for unassigned driving segment

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -4255,7 +4255,8 @@
                         "ACCEPTED",
                         "REJECTED",
                         "UNASSIGNED",
-                        "UNKNOWN"
+                        "UNKNOWN",
+                        "ANNOTATED"
                     ],
                     "example": "PENDING"
                 },


### PR DESCRIPTION
Introduces ANNOTATED as a possible status for an unassigned driving segment. The ANNOTATED status represents when an unassigned driving segment has no associated driver and has been annotated.