### PR TITLE
workflows: adding the option to manually trigger github workflow

### DIFF
--- a/.github/workflows/readme-api-sync.yml
+++ b/.github/workflows/readme-api-sync.yml
@@ -1,5 +1,6 @@
 name: Sync OAS to ReadMe
 on:
+  workflow_dispatch:
   push:
     branches:
       - master


### PR DESCRIPTION
Adding the workflow_dispatch option to the Sync OAS to ReadMe workflow
so we can manually run the workflow when needed (for debugging)