### PR TITLE
workflows: change condition of readme sync to happen on doc changes

### DIFF
--- a/.github/workflows/readme-api-sync.yml
+++ b/.github/workflows/readme-api-sync.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'swagger-readme.json'
+      - 'markdown/**'
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add extra conditions to the readme sync workflow to happen only when
swagger-readme.json or any files under markdown directory is changed
on the master branch.