### PR TITLE
scripts: change markdown file path

### DIFF
--- a/scripts/readme_orderer.py
+++ b/scripts/readme_orderer.py
@@ -14,7 +14,7 @@ class BasicAuth(requests.auth.AuthBase):
 
 # Read markdown files and store by slug.
 slugToBody = {}
-markdownFilePath = "./markdown/readme"
+markdownFilePath = "./markdown"
 
 files = []
 for f in os.listdir(markdownFilePath):


### PR DESCRIPTION
Changing the file path that the python script looks to sync markdown files.
This was changed in the backend repo to only put files in the /markdown
directory instead of creating a nested readme directory.