### PR TITLE
OpenAPI data type fixes

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -9649,7 +9649,6 @@
       "properties": {
         "addressTypes": {
           "description": "Reporting location type associated with the address (used for ELD reporting purposes).",
-          "type": "array",
           "items": {
             "type": "string",
             "enum": [
@@ -10938,7 +10937,6 @@
       "properties": {
         "addressTypes": {
           "description": "Reporting location type associated with the address (used for ELD reporting purposes).",
-          "type": "array",
           "items": {
             "type": "string",
             "enum": [
@@ -24917,7 +24915,6 @@
       "properties": {
         "addressTypes": {
           "description": "Reporting location type associated with the address (used for ELD reporting purposes).",
-          "type": "array",
           "items": {
             "type": "string",
             "enum": [

--- a/swagger.json
+++ b/swagger.json
@@ -7721,7 +7721,7 @@
             "in": "query"
           },
           {
-            "type": "number",
+            "type": "integer",
             "format": "int64",
             "description": "Pagination parameter indicating the number of results to return in this request. Used in conjunction with either 'startingAfter' or 'endingBefore'.",
             "name": "limit",
@@ -7793,7 +7793,7 @@
             "in": "query"
           },
           {
-            "type": "number",
+            "type": "integer",
             "format": "int64",
             "description": "Pagination parameter indicating the number of results to return in this request. Used in conjunction with either 'startingAfter' or 'endingBefore'.",
             "name": "limit",
@@ -8702,7 +8702,7 @@
             "in": "query"
           },
           {
-            "type": "number",
+            "type": "integer",
             "format": "int64",
             "description": "Pagination parameter indicating the number of results to return in this request. Used in conjunction with either 'startingAfter' or 'endingBefore'.",
             "name": "limit",


### PR DESCRIPTION
There are two fixes required for the OpenAPI specification.  First is that the container of enums shouldn't be array because it causes the type to be interpreted as Seq[MyEnum] and causes OpenAPI Generator to create code that won't compile.  Second is that "int64" should consistently have "integer" type rather than the more general "number" type.   This prevents OpenAPI generator from using BigDecimal for what should be a primitive and failing to compile.